### PR TITLE
Small fix in TTURLCache

### DIFF
--- a/src/Three20Network/Sources/TTURLCache.m
+++ b/src/Three20Network/Sources/TTURLCache.m
@@ -252,8 +252,7 @@ static NSMutableDictionary* gNamedCaches = nil;
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (UIImage*)loadImageFromDocuments:(NSString*)URL {
   NSString* path = TTPathForDocumentsResource([URL substringFromIndex:12]);
-  NSData* data = [NSData dataWithContentsOfFile:path];
-  return [UIImage imageWithData:data];
+  return [UIImage imageWithContentsOfFile:path];
 }
 
 


### PR DESCRIPTION
By using UIImage to load image data from a file, the proper scale is set for high resolution screens.  Without this, the high resolution images are displayed at the double the intended size. (I've encountered this issue in conjunction with TTLauncherButton).
