### PR TITLE
fix table view cell rendering  issue when tableview is pop after orientation was changed

### DIFF
--- a/src/Three20UI/Sources/TTTableViewController.m
+++ b/src/Three20UI/Sources/TTTableViewController.m
@@ -252,7 +252,10 @@ static const CGFloat kBannerViewHeight = 22;
 
   if (_lastInterfaceOrientation != self.interfaceOrientation) {
     _lastInterfaceOrientation = self.interfaceOrientation;
+	NSIndexPath *selectedRow = [[_tableView indexPathForSelectedRow] retain];
     [_tableView reloadData];
+	[_tableView selectRowAtIndexPath:selectedRow animated:NO scrollPosition:UITableViewScrollPositionNone];
+	[selectedRow release];
   } else if ([_tableView isKindOfClass:[TTTableView class]]) {
     TTTableView* tableView = (TTTableView*)_tableView;
     tableView.highlightedLabel = nil;


### PR DESCRIPTION
Hi, this pull request contains bugfix for table view cell rendering issue which occurs when a tableview is pop after device orientation was changed.

Rgds,
Meiwin
