### PR TITLE
Misc changes to Three20

### DIFF
--- a/src/Three20/Three20.xcodeproj/project.pbxproj
+++ b/src/Three20/Three20.xcodeproj/project.pbxproj
@@ -684,14 +684,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6E64543D1184BE1B00F08CB1 /* Project.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_UNIVERSAL_IPHONE_OS)";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PREBINDING = NO;
-				SDKROOT = iphonesimulator3.2;
 			};
 			name = Internal;
 		};
@@ -758,14 +755,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6E64543D1184BE1B00F08CB1 /* Project.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_UNIVERSAL_IPHONE_OS)";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PREBINDING = NO;
-				SDKROOT = iphonesimulator3.2;
 			};
 			name = Debug;
 		};
@@ -773,13 +767,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6E64543D1184BE1B00F08CB1 /* Project.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_UNIVERSAL_IPHONE_OS)";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PREBINDING = NO;
-				SDKROOT = iphonesimulator3.2;
 			};
 			name = Release;
 		};

--- a/src/Three20/Three20.xcodeproj/project.pbxproj
+++ b/src/Three20/Three20.xcodeproj/project.pbxproj
@@ -427,7 +427,14 @@
 			isa = PBXProject;
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "Three20" */;
 			compatibilityVersion = "Xcode 3.1";
+			developmentRegion = English;
 			hasScannedForEncodings = 1;
+			knownRegions = (
+				English,
+				Japanese,
+				French,
+				German,
+			);
 			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			projectDirPath = "";
 			projectReferences = (

--- a/src/Three20Core/Sources/TTEntityTables.m
+++ b/src/Three20Core/Sources/TTEntityTables.m
@@ -164,11 +164,11 @@ static TTEntityTables* sharedInstance = nil;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 + (id)sharedInstance {
-  @synchronized(self) {
+//  @synchronized(self) {
     if (nil == sharedInstance) {
       sharedInstance = [[self alloc] init];
     }
-  }
+//  }
   return sharedInstance;
 }
 
@@ -181,21 +181,21 @@ static TTEntityTables* sharedInstance = nil;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 + (void)releaseSharedInstance {
-  @synchronized(self) {
+//  @synchronized(self) {
     [sharedInstance superRelease];
     sharedInstance = nil;
-  }
+//  }
 }
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Ensure that [TTEntityTables alloc] returns the singleton object.
 + (id)allocWithZone:(NSZone*)zone {
-  @synchronized(self) {
+//  @synchronized(self) {
     if (nil == sharedInstance) {
       sharedInstance = [super allocWithZone:zone];
     }
-  }
+//  }
 
   return sharedInstance;
 }

--- a/src/Three20Core/Three20Core.xcodeproj/project.pbxproj
+++ b/src/Three20Core/Three20Core.xcodeproj/project.pbxproj
@@ -346,7 +346,14 @@
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "Three20Core" */;
 			compatibilityVersion = "Xcode 3.1";
+			developmentRegion = English;
 			hasScannedForEncodings = 1;
+			knownRegions = (
+				English,
+				Japanese,
+				French,
+				German,
+			);
 			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -444,14 +451,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6E6454021184BDD500F08CB1 /* Project.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_UNIVERSAL_IPHONE_OS)";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PREBINDING = NO;
-				SDKROOT = iphonesimulator3.2;
 			};
 			name = Internal;
 		};
@@ -512,14 +516,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6E6454021184BDD500F08CB1 /* Project.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_UNIVERSAL_IPHONE_OS)";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PREBINDING = NO;
-				SDKROOT = iphonesimulator3.2;
 			};
 			name = Debug;
 		};
@@ -527,14 +528,12 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6E6454021184BDD500F08CB1 /* Project.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_UNIVERSAL_IPHONE_OS)";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_CHECK_SWITCH_STATEMENTS = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PREBINDING = NO;
-				SDKROOT = iphonesimulator3.2;
 			};
 			name = Release;
 		};

--- a/src/Three20Network/Three20Network.xcodeproj/project.pbxproj
+++ b/src/Three20Network/Three20Network.xcodeproj/project.pbxproj
@@ -403,7 +403,14 @@
 			isa = PBXProject;
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "Three20Network" */;
 			compatibilityVersion = "Xcode 3.1";
+			developmentRegion = English;
 			hasScannedForEncodings = 1;
+			knownRegions = (
+				English,
+				Japanese,
+				French,
+				German,
+			);
 			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			projectDirPath = "";
 			projectReferences = (
@@ -529,14 +536,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6E64541F1184BDF900F08CB1 /* Project.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_UNIVERSAL_IPHONE_OS)";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PREBINDING = NO;
-				SDKROOT = iphonesimulator3.2;
 			};
 			name = Internal;
 		};
@@ -604,14 +608,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6E64541F1184BDF900F08CB1 /* Project.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_UNIVERSAL_IPHONE_OS)";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PREBINDING = NO;
-				SDKROOT = iphonesimulator3.2;
 			};
 			name = Debug;
 		};
@@ -619,13 +620,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6E64541F1184BDF900F08CB1 /* Project.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_UNIVERSAL_IPHONE_OS)";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PREBINDING = NO;
-				SDKROOT = iphonesimulator3.2;
 			};
 			name = Release;
 		};

--- a/src/Three20Style/Headers/TTStyledText.h
+++ b/src/Three20Style/Headers/TTStyledText.h
@@ -137,4 +137,9 @@
 
 - (TTStyledNode*)getElementByClassName:(NSString*)className;
 
+/**
+ * Returns a plain text version of the styled text.
+ */
+- (NSString*)plainText;
+
 @end

--- a/src/Three20Style/Sources/TTStyledText.m
+++ b/src/Three20Style/Sources/TTStyledText.m
@@ -451,4 +451,18 @@
 }
 
 
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (NSString*)plainText
+{
+	NSMutableArray *t = [NSMutableArray arrayWithCapacity:32];
+	TTStyledNode* node = _rootNode;
+	while (node) {
+		NSString *nodeText = [node outerText];
+		if([nodeText length] > 0) [t addObject:nodeText];
+		node = node.nextSibling;
+	}
+	return [t componentsJoinedByString:@"\n"];
+}
+
+
 @end

--- a/src/Three20Style/Three20Style.xcodeproj/project.pbxproj
+++ b/src/Three20Style/Three20Style.xcodeproj/project.pbxproj
@@ -855,7 +855,14 @@
 			isa = PBXProject;
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "Three20Style" */;
 			compatibilityVersion = "Xcode 3.1";
+			developmentRegion = English;
 			hasScannedForEncodings = 1;
+			knownRegions = (
+				English,
+				Japanese,
+				French,
+				German,
+			);
 			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			projectDirPath = "";
 			projectReferences = (
@@ -1058,14 +1065,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6E64543D1184BE1B00F08CB1 /* Project.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_UNIVERSAL_IPHONE_OS)";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PREBINDING = NO;
-				SDKROOT = iphonesimulator3.2;
 			};
 			name = Internal;
 		};
@@ -1133,14 +1137,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6E64543D1184BE1B00F08CB1 /* Project.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_UNIVERSAL_IPHONE_OS)";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PREBINDING = NO;
-				SDKROOT = iphonesimulator3.2;
 			};
 			name = Debug;
 		};
@@ -1148,13 +1149,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6E64543D1184BE1B00F08CB1 /* Project.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_UNIVERSAL_IPHONE_OS)";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PREBINDING = NO;
-				SDKROOT = iphonesimulator3.2;
 			};
 			name = Release;
 		};

--- a/src/Three20UI/Headers/TTStyledTextTableItemCell.h
+++ b/src/Three20UI/Headers/TTStyledTextTableItemCell.h
@@ -18,11 +18,14 @@
 #import "Three20UI/TTTableLinkedItemCell.h"
 
 @class TTStyledTextLabel;
+@class TTImageView;
 
 @interface TTStyledTextTableItemCell : TTTableLinkedItemCell {
   TTStyledTextLabel* _label;
+  TTImageView* _imageView2;
 }
 
 @property (nonatomic, readonly) TTStyledTextLabel* label;
+@property (nonatomic, readonly, retain) TTImageView* imageView2;
 
 @end

--- a/src/Three20UI/Headers/TTTableItem.h
+++ b/src/Three20UI/Headers/TTTableItem.h
@@ -23,4 +23,9 @@
 
 @property (nonatomic, retain) id userInfo;
 
+/**
+ * Returns the text which should be copied to the pasteboard from this cell
+ */
+- (NSString*)textForCopyingToPasteboard;
+
 @end

--- a/src/Three20UI/Headers/TTTableStyledTextItem.h
+++ b/src/Three20UI/Headers/TTTableStyledTextItem.h
@@ -21,16 +21,19 @@
 
 @interface TTTableStyledTextItem : TTTableLinkedItem {
   TTStyledText* _text;
+  NSString*     _imageURL;
   UIEdgeInsets  _margin;
   UIEdgeInsets  _padding;
 }
 
 @property (nonatomic, retain) TTStyledText* text;
+@property (nonatomic,copy)    NSString*     imageURL;
 @property (nonatomic)         UIEdgeInsets  margin;
 @property (nonatomic)         UIEdgeInsets  padding;
 
 + (id)itemWithText:(TTStyledText*)text;
 + (id)itemWithText:(TTStyledText*)text URL:(NSString*)URL;
 + (id)itemWithText:(TTStyledText*)text URL:(NSString*)URL accessoryURL:(NSString*)accessoryURL;
++ (id)itemWithText:(TTStyledText*)text imageURL:(NSString*)imageURL URL:(NSString*)URL accessoryURL:(NSString*)accessoryURL;
 
 @end

--- a/src/Three20UI/Sources/TTStyledTextTableItemCell.m
+++ b/src/Three20UI/Sources/TTStyledTextTableItemCell.m
@@ -75,13 +75,14 @@ static const CGFloat kDisclosureIndicatorWidth = 23;
   }
 
   CGFloat padding = [tableView tableCellMargin]*2 + item.padding.left + item.padding.right;
+  padding += item.margin.left + item.margin.right;
   if (item.URL) {
     padding += kDisclosureIndicatorWidth;
   }
 
   item.text.width = tableView.width - padding;
 
-  return item.text.height + item.padding.top + item.padding.bottom;
+  return item.text.height + item.padding.top + item.padding.bottom + item.margin.top + item.margin.bottom;
 }
 
 
@@ -96,7 +97,7 @@ static const CGFloat kDisclosureIndicatorWidth = 23;
   [super layoutSubviews];
 
   TTTableStyledTextItem* item = self.object;
-  _label.frame = CGRectOffset(self.contentView.bounds, item.margin.left, item.margin.top);
+  _label.frame = UIEdgeInsetsInsetRect(self.contentView.bounds, item.margin);
 }
 
 

--- a/src/Three20UI/Sources/TTTableCaptionItemCell.m
+++ b/src/Three20UI/Sources/TTTableCaptionItemCell.m
@@ -45,12 +45,12 @@ static const CGFloat kKeyWidth = 75;
     self.textLabel.textAlignment = UITextAlignmentRight;
     self.textLabel.lineBreakMode = UILineBreakModeTailTruncation;
     self.textLabel.numberOfLines = 1;
-    self.textLabel.adjustsFontSizeToFitWidth = YES;
+    // self.textLabel.adjustsFontSizeToFitWidth = YES;
 
     self.detailTextLabel.font = TTSTYLEVAR(tableSmallFont);
     self.detailTextLabel.textColor = TTSTYLEVAR(textColor);
     self.detailTextLabel.highlightedTextColor = TTSTYLEVAR(highlightedTextColor);
-    self.detailTextLabel.adjustsFontSizeToFitWidth = YES;
+    // self.detailTextLabel.adjustsFontSizeToFitWidth = YES;
     self.detailTextLabel.minimumFontSize = 8;
     self.detailTextLabel.lineBreakMode = UILineBreakModeWordWrap;
     self.detailTextLabel.numberOfLines = 0;

--- a/src/Three20UI/Sources/TTTableItem.m
+++ b/src/Three20UI/Sources/TTTableItem.m
@@ -56,4 +56,15 @@
 }
 
 
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Support for TTTableViewCell's text copying
+
+- (NSString*)textForCopyingToPasteboard {
+	if([self respondsToSelector:@selector(text)])
+	{
+		return [(id)self text];
+	}
+	return nil;
+}
+
 @end

--- a/src/Three20UI/Sources/TTTableMessageItemCell.m
+++ b/src/Three20UI/Sources/TTTableMessageItemCell.m
@@ -49,7 +49,7 @@ static const CGFloat    kDefaultMessageImageHeight  = 34;
     self.textLabel.highlightedTextColor = TTSTYLEVAR(highlightedTextColor);
     self.textLabel.textAlignment = UITextAlignmentLeft;
     self.textLabel.lineBreakMode = UILineBreakModeTailTruncation;
-    self.textLabel.adjustsFontSizeToFitWidth = YES;
+    // self.textLabel.adjustsFontSizeToFitWidth = YES;
     self.textLabel.contentMode = UIViewContentModeLeft;
 
     self.detailTextLabel.font = TTSTYLEVAR(font);

--- a/src/Three20UI/Sources/TTTableStyledTextItem.m
+++ b/src/Three20UI/Sources/TTTableStyledTextItem.m
@@ -26,6 +26,7 @@
 @implementation TTTableStyledTextItem
 
 @synthesize text    = _text;
+@synthesize imageURL= _imageURL;
 @synthesize margin  = _margin;
 @synthesize padding = _padding;
 
@@ -44,6 +45,7 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)dealloc {
   TT_RELEASE_SAFELY(_text);
+  TT_RELEASE_SAFELY(_imageURL);
 
   [super dealloc];
 }
@@ -76,6 +78,17 @@
 + (id)itemWithText:(TTStyledText*)text URL:(NSString*)URL accessoryURL:(NSString*)accessoryURL {
   TTTableStyledTextItem* item = [[[self alloc] init] autorelease];
   item.text = text;
+  item.URL = URL;
+  item.accessoryURL = accessoryURL;
+  return item;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
++ (id)itemWithText:(TTStyledText*)text imageURL:(NSString*)imageURL URL:(NSString*)URL accessoryURL:(NSString*)accessoryURL {
+  TTTableStyledTextItem* item = [[[self alloc] init] autorelease];
+  item.text = text;
+  item.imageURL = imageURL;
   item.URL = URL;
   item.accessoryURL = accessoryURL;
   return item;

--- a/src/Three20UI/Sources/TTTableStyledTextItem.m
+++ b/src/Three20UI/Sources/TTTableStyledTextItem.m
@@ -16,6 +16,9 @@
 
 #import "Three20UI/TTTableStyledTextItem.h"
 
+// Styles
+#import "Three20Style/TTStyledText.h"
+
 // Core
 #import "Three20Core/TTCorePreprocessorMacros.h"
 
@@ -118,5 +121,10 @@
   }
 }
 
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (NSString*)textForCopyingToPasteboard {
+	return [self.text plainText];
+}
 
 @end

--- a/src/Three20UI/Sources/TTTableSubtextItemCell.m
+++ b/src/Three20UI/Sources/TTTableSubtextItemCell.m
@@ -37,7 +37,7 @@
     self.detailTextLabel.font = TTSTYLEVAR(tableFont);
     self.detailTextLabel.textColor = TTSTYLEVAR(textColor);
     self.detailTextLabel.highlightedTextColor = TTSTYLEVAR(highlightedTextColor);
-    self.detailTextLabel.adjustsFontSizeToFitWidth = YES;
+    // self.detailTextLabel.adjustsFontSizeToFitWidth = YES;
 
     self.textLabel.font = TTSTYLEVAR(font);
     self.textLabel.textColor = TTSTYLEVAR(tableSubTextColor);

--- a/src/Three20UI/Sources/TTTableSubtitleItem.m
+++ b/src/Three20UI/Sources/TTTableSubtitleItem.m
@@ -131,4 +131,9 @@
 }
 
 
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (NSString*)textForCopyingToPasteboard {
+	return [NSString stringWithFormat:@"%@\n%@", self.text, self.subtitle];
+}
+
 @end

--- a/src/Three20UI/Sources/TTTableSubtitleItemCell.m
+++ b/src/Three20UI/Sources/TTTableSubtitleItemCell.m
@@ -16,6 +16,9 @@
 
 #import "Three20UI/TTTableSubtitleItemCell.h"
 
+// Network
+#import "Three20Network/TTURLCache.h"
+
 // UI
 #import "Three20UI/TTImageView.h"
 #import "Three20UI/TTTableSubtitleItem.h"
@@ -29,6 +32,8 @@
 // Core
 #import "Three20Core/TTCorePreprocessorMacros.h"
 
+static const CGFloat kHPadding = 8;
+static const CGFloat kDefaultImageSize = 50;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -98,13 +103,27 @@
 
   CGFloat height = self.contentView.height;
   CGFloat width = self.contentView.width - (height + kTableCellSmallMargin);
-  CGFloat left = 0;
+  CGFloat left = kHPadding;
 
-  if (_imageView2) {
-    _imageView2.frame = CGRectMake(0, 0, height, height);
-    left = _imageView2.right + kTableCellSmallMargin;
-  } else {
-    left = kTableCellHPadding;
+  if (_imageView2.urlPath) {
+    // Code modified using TTTableImageItemCell as a model - use the image at the unscaled size
+    TTTableSubtitleItem* item = self.object;
+    UIImage* image = item.imageURL ? [[TTURLCache sharedCache] imageForURL:item.imageURL] : nil;
+    if (!image) {
+      image = item.defaultImage;
+    }
+
+    CGFloat iconWidth = image
+      ? image.size.width
+      : (item.imageURL ? kDefaultImageSize : 0);
+    CGFloat iconHeight = image
+      ? image.size.height
+      : (item.imageURL ? kDefaultImageSize : 0);
+
+    _imageView2.frame = CGRectMake(kHPadding, floor(self.height/2 - iconHeight/2),
+                                 iconWidth, iconHeight);
+
+    left += kHPadding + iconWidth;
   }
 
   if (self.detailTextLabel.text.length) {

--- a/src/Three20UI/Sources/TTTableSubtitleItemCell.m
+++ b/src/Three20UI/Sources/TTTableSubtitleItemCell.m
@@ -49,7 +49,7 @@ static const CGFloat kDefaultImageSize = 50;
     self.textLabel.highlightedTextColor = TTSTYLEVAR(highlightedTextColor);
     self.textLabel.textAlignment = UITextAlignmentLeft;
     self.textLabel.lineBreakMode = UILineBreakModeTailTruncation;
-    self.textLabel.adjustsFontSizeToFitWidth = YES;
+    // self.textLabel.adjustsFontSizeToFitWidth = YES;
 
     self.detailTextLabel.font = TTSTYLEVAR(font);
     self.detailTextLabel.textColor = TTSTYLEVAR(tableSubTextColor);

--- a/src/Three20UI/Sources/TTTableViewCell.m
+++ b/src/Three20UI/Sources/TTTableViewCell.m
@@ -64,4 +64,39 @@ const NSInteger kTableMessageTextLineCount = 2;
 }
 
 
+///////////////////////////////////////////////////////////////////////////////////////////////////
+//   Copy & Paste support 
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Allow the cell to become a first responder so UIMenuController will ask it to perform the copy operation
+- (BOOL)canBecomeFirstResponder {
+	return YES;
+}
+
+// Get the text for the pasteboard copy, or nil
+- (NSString*)textForCopyingToPasteboard {
+	id obj = [self object];
+	if(obj != nil && [obj respondsToSelector:@selector(textForCopyingToPasteboard)])
+	{
+		return [obj textForCopyingToPasteboard];
+	}
+	return nil;
+}
+
+// This cell will allow copy operations if there's some text available
+- (BOOL)canPerformAction:(SEL)action withSender:(id)sender {
+	return (action == @selector(copy:) && [self textForCopyingToPasteboard] != nil) || [super canPerformAction:action withSender:sender];
+}
+
+// Perform copy operations
+- (void)copy:(id)sender {
+	NSString *text = [self textForCopyingToPasteboard];
+	if(text != nil)
+	{
+		[[UIPasteboard generalPasteboard] setString:text];
+	}
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
 @end

--- a/src/Three20UI/Three20UI.xcodeproj/project.pbxproj
+++ b/src/Three20UI/Three20UI.xcodeproj/project.pbxproj
@@ -1876,7 +1876,14 @@
 			isa = PBXProject;
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "Three20UI" */;
 			compatibilityVersion = "Xcode 3.1";
+			developmentRegion = English;
 			hasScannedForEncodings = 1;
+			knownRegions = (
+				English,
+				Japanese,
+				French,
+				German,
+			);
 			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			projectDirPath = "";
 			projectReferences = (
@@ -2221,14 +2228,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6E64543D1184BE1B00F08CB1 /* Project.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_UNIVERSAL_IPHONE_OS)";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PREBINDING = NO;
-				SDKROOT = iphonesimulator3.2;
 			};
 			name = Internal;
 		};
@@ -2296,14 +2300,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6E64543D1184BE1B00F08CB1 /* Project.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_UNIVERSAL_IPHONE_OS)";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PREBINDING = NO;
-				SDKROOT = iphonesimulator3.2;
 			};
 			name = Debug;
 		};
@@ -2311,13 +2312,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6E64543D1184BE1B00F08CB1 /* Project.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_UNIVERSAL_IPHONE_OS)";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PREBINDING = NO;
-				SDKROOT = iphonesimulator3.2;
 			};
 			name = Release;
 		};

--- a/src/Three20UICommon/Three20UICommon.xcodeproj/project.pbxproj
+++ b/src/Three20UICommon/Three20UICommon.xcodeproj/project.pbxproj
@@ -283,7 +283,14 @@
 			isa = PBXProject;
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "Three20UICommon" */;
 			compatibilityVersion = "Xcode 3.1";
+			developmentRegion = English;
 			hasScannedForEncodings = 1;
+			knownRegions = (
+				English,
+				Japanese,
+				French,
+				German,
+			);
 			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			projectDirPath = "";
 			projectReferences = (
@@ -403,14 +410,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6E64543D1184BE1B00F08CB1 /* Project.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_UNIVERSAL_IPHONE_OS)";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PREBINDING = NO;
-				SDKROOT = iphonesimulator3.2;
 			};
 			name = Internal;
 		};
@@ -478,14 +482,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6E64543D1184BE1B00F08CB1 /* Project.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_UNIVERSAL_IPHONE_OS)";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PREBINDING = NO;
-				SDKROOT = iphonesimulator3.2;
 			};
 			name = Debug;
 		};
@@ -493,13 +494,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6E64543D1184BE1B00F08CB1 /* Project.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_UNIVERSAL_IPHONE_OS)";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PREBINDING = NO;
-				SDKROOT = iphonesimulator3.2;
 			};
 			name = Release;
 		};

--- a/src/Three20UINavigator/Three20UINavigator.xcodeproj/project.pbxproj
+++ b/src/Three20UINavigator/Three20UINavigator.xcodeproj/project.pbxproj
@@ -503,7 +503,14 @@
 			isa = PBXProject;
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "Three20UINavigator" */;
 			compatibilityVersion = "Xcode 3.1";
+			developmentRegion = English;
 			hasScannedForEncodings = 1;
+			knownRegions = (
+				English,
+				Japanese,
+				French,
+				German,
+			);
 			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			projectDirPath = "";
 			projectReferences = (
@@ -662,14 +669,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6E64543D1184BE1B00F08CB1 /* Project.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_UNIVERSAL_IPHONE_OS)";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PREBINDING = NO;
-				SDKROOT = iphonesimulator3.2;
 			};
 			name = Internal;
 		};
@@ -737,14 +741,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6E64543D1184BE1B00F08CB1 /* Project.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_UNIVERSAL_IPHONE_OS)";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PREBINDING = NO;
-				SDKROOT = iphonesimulator3.2;
 			};
 			name = Debug;
 		};
@@ -752,13 +753,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6E64543D1184BE1B00F08CB1 /* Project.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_UNIVERSAL_IPHONE_OS)";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PREBINDING = NO;
-				SDKROOT = iphonesimulator3.2;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
I needed to make some tweaks to Three20 for my app, and just wondered if any of them might be useful for the core.

The ones you might want are the start of pasteboard support for copying table cells, and a fix for margin and padding calculations in TTStyledTextTableItemCell so it displays correctly inside a cell with rounded corners, and optional display of an image in TTTableStyledTextItem.

The other two are probably just for my app, and make things a little more consistent in display. They would probably break other apps, but I thought you might want to see them anyway.

Thanks!
