### PR TITLE
Download tracking implemented to TTURLRequest

### DIFF
--- a/src/Three20Network/Headers/TTURLRequest.h
+++ b/src/Three20Network/Headers/TTURLRequest.h
@@ -54,6 +54,9 @@
 
   NSInteger             _totalBytesLoaded;
   NSInteger             _totalBytesExpected;
+    
+  NSInteger             _totalBytesDownloaded;
+  NSInteger             _totalContentLength;
 
   id    _userInfo;
 
@@ -179,6 +182,16 @@
  * The number of expected bytes from this request.
  */
 @property (nonatomic) NSInteger totalBytesExpected;
+
+/**
+ * The number of downloaded bytes from server.
+ */
+@property (nonatomic) NSInteger totalBytesDownloaded;
+
+/**
+ *  The number of content length of request.
+ */
+@property (nonatomic) NSInteger totalContentLength;
 
 /**
  * Whether or not the request was loaded from the cache.

--- a/src/Three20Network/Sources/TTRequestLoader.m
+++ b/src/Three20Network/Sources/TTRequestLoader.m
@@ -294,12 +294,20 @@ static const NSInteger kLoadMaxRetries = 2;
   }
 
   _responseData = [[NSMutableData alloc] initWithCapacity:contentLength];
+    
+    for (TTURLRequest* request in [[_requests copy] autorelease]) {
+        request.totalContentLength = contentLength;
+    }
+    
 }
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)connection:(NSURLConnection*)connection didReceiveData:(NSData*)data {
   [_responseData appendData:data];
+    for (TTURLRequest* request in [[_requests copy] autorelease]) {
+        request.totalBytesDownloaded += [data length];
+    }
 }
 
 

--- a/src/Three20Network/Sources/TTURLRequest.m
+++ b/src/Three20Network/Sources/TTURLRequest.m
@@ -55,6 +55,9 @@ static NSString* kStringBoundary = @"3i2ndDfv2rTHiSisAbouNdArYfORhtTPEefj3q2f";
 @synthesize totalBytesLoaded      = _totalBytesLoaded;
 @synthesize totalBytesExpected    = _totalBytesExpected;
 
+@synthesize totalBytesDownloaded  = _totalBytesDownloaded;
+@synthesize totalContentLength    = _totalContentLength;
+
 @synthesize userInfo              = _userInfo;
 @synthesize isLoading             = _isLoading;
 
@@ -304,7 +307,6 @@ static NSString* kStringBoundary = @"3i2ndDfv2rTHiSisAbouNdArYfORhtTPEefj3q2f";
   }
   return [[TTURLRequestQueue mainQueue] sendRequest:self];
 }
-
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (BOOL)sendSynchronously {


### PR DESCRIPTION
With this small change you can track download status from TTURLRequest of you model. It's good with big files. Easy to implement with TTActivityLabel.  I have also implemented a category for TTURLRequestModel, but its not included in this commit. I'm adding it to comment.

//=====================

@implementation TTURLRequestModel (CBGNPAdditions)
- (CGFloat)loadedRatio {
  if (!!_loadingRequest) {
    if (_loadingRequest.totalBytesDownloaded > 0) {
      return ((float)_loadingRequest.totalBytesDownloaded / (float)_loadingRequest.totalContentLength);
    }
    return 0;
  }
  else if (!!_loadedTime) {
    return 1;
  }
  else {
    return 0;
  }

}

@end
