### PR TITLE
Redirectresponses

### DIFF
--- a/src/Three20Network/Headers/TTRequestLoader.h
+++ b/src/Three20Network/Headers/TTRequestLoader.h
@@ -125,6 +125,8 @@
 - (BOOL)cancel:(TTURLRequest*)request;
 
 - (NSError*)processResponse:(NSHTTPURLResponse*)response data:(id)data;
+- (NSURLRequest*)dispatchWillSendRequest: (NSURLRequest*)request
+                        redirectResponse: (NSURLResponse*)response;
 - (void)dispatchError:(NSError*)error;
 - (void)dispatchLoaded:(NSDate*)timestamp;
 - (void)dispatchAuthenticationChallenge:(NSURLAuthenticationChallenge*)challenge;

--- a/src/Three20Network/Headers/TTURLRequestDelegate.h
+++ b/src/Three20Network/Headers/TTURLRequestDelegate.h
@@ -22,6 +22,17 @@
 @optional
 
 /**
+ * The request has determined that it must change URLs to continue.
+ * sendRequest is the new request object to use.
+ *
+ * The default is to return sendRequest. If you would like to change the redirection,
+ * create a new NSURLRequest object and return that instead.
+ */
+- (NSURLRequest*)request: (TTURLRequest*)request
+         willSendRequest: (NSURLRequest*)sendRequest
+        redirectResponse: (NSURLResponse*)redirectResponse;
+
+/**
  * The request has begun loading.
  *
  * This method will not be called if the data is loaded immediately from the cache.

--- a/src/Three20Network/Headers/TTURLRequestQueueInternal.h
+++ b/src/Three20Network/Headers/TTURLRequestQueueInternal.h
@@ -23,6 +23,10 @@
  */
 @interface TTURLRequestQueue (TTRequestLoader)
 
+- (NSURLRequest*)loader: (TTRequestLoader*)loader
+        willSendRequest: (NSURLRequest*)request
+       redirectResponse: (NSURLResponse*)redirectResponse;
+
 - (void)                       loader: (TTRequestLoader*)loader
     didReceiveAuthenticationChallenge: (NSURLAuthenticationChallenge*)challenge;
 

--- a/src/Three20Network/Sources/TTRequestLoader.m
+++ b/src/Three20Network/Sources/TTRequestLoader.m
@@ -217,6 +217,26 @@ static const NSInteger kLoadMaxRetries = 2;
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
+- (NSURLRequest*)dispatchWillSendRequest: (NSURLRequest*)request
+                        redirectResponse: (NSURLResponse*)response {
+  for (TTURLRequest* requestIterator in [[_requests copy] autorelease]) {
+    for (id<TTURLRequestDelegate> delegate in requestIterator.delegates) {
+      if ([delegate respondsToSelector:@selector(request:willSendRequest:redirectResponse:)]) {
+        NSURLRequest* result = [delegate request: requestIterator
+                                 willSendRequest: request
+                                redirectResponse: response];
+        if (result != request) {
+          return result;
+        }
+      }
+    }
+  }
+
+  return request;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)dispatchError:(NSError*)error {
   for (TTURLRequest* request in [[_requests copy] autorelease]) {
     request.isLoading = NO;
@@ -272,6 +292,14 @@ static const NSInteger kLoadMaxRetries = 2;
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark -
 #pragma mark NSURLConnectionDelegate
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (NSURLRequest*)connection: (NSURLConnection*)connection
+            willSendRequest: (NSURLRequest*)request
+           redirectResponse: (NSURLResponse*)response {
+  return [_queue loader:self willSendRequest:request redirectResponse:response];
+}
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/Three20Network/Sources/TTURLRequestQueue.m
+++ b/src/Three20Network/Sources/TTURLRequestQueue.m
@@ -637,7 +637,7 @@ static TTURLRequestQueue* gMainQueue = nil;
   NSDate* timestamp = nil;
   if ([self loadFromCache:loader.urlPath cacheKey:loader.cacheKey
                   expires:TT_CACHE_EXPIRATION_AGE_NEVER
-                 fromDisk:!_suspended && (loader.cachePolicy & TTURLRequestCachePolicyDisk)
+                 fromDisk:YES
                      data:&data error:&error timestamp:&timestamp]) {
 
     if (nil == error) {

--- a/src/Three20Network/Sources/TTURLRequestQueue.m
+++ b/src/Three20Network/Sources/TTURLRequestQueue.m
@@ -549,6 +549,14 @@ static TTURLRequestQueue* gMainQueue = nil;
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
+- (NSURLRequest*)loader: (TTRequestLoader*)loader
+        willSendRequest: (NSURLRequest*)request
+       redirectResponse: (NSURLResponse*)redirectResponse {
+  return [loader dispatchWillSendRequest:request redirectResponse:redirectResponse];
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)     loader: (TTRequestLoader*)loader
     didLoadResponse: (NSHTTPURLResponse*)response
                data: (id)data {

--- a/src/Three20Network/Sources/TTURLRequestQueue.m
+++ b/src/Three20Network/Sources/TTURLRequestQueue.m
@@ -261,6 +261,7 @@ static TTURLRequestQueue* gMainQueue = nil;
   NSError* error = nil;
 
   if ((loader.cachePolicy & (TTURLRequestCachePolicyDisk|TTURLRequestCachePolicyMemory))
+	  && !IS_MASK_SET(loader.cachePolicy, TTURLRequestCachePolicyEtag)
       && [self loadFromCache:loader.urlPath cacheKey:loader.cacheKey
                expires:loader.cacheExpirationAge
                fromDisk:loader.cachePolicy & TTURLRequestCachePolicyDisk


### PR DESCRIPTION
This branch builds upon some work done earlier this summer to allow redirecting responses in TTURLRequest (http://groups.google.com/group/three20/browse_thread/thread/d07c1e40bc598648/12613f75f4972b74).

In addition to redirect responses support, the following issues are fixed:

http://github.com/facebook/three20/issuesearch?state=open&q=etag#issue/218
http://github.com/facebook/three20/issuesearch?state=open&q=wlach#issue/226
