### PR TITLE
Small fix for TTTableCaptionItemCell

### DIFF
--- a/src/Three20UI/Sources/TTTableCaptionItemCell.m
+++ b/src/Three20UI/Sources/TTTableCaptionItemCell.m
@@ -77,7 +77,11 @@ static const CGFloat kKeyWidth = 75;
                                 constrainedToSize:CGSizeMake(width, CGFLOAT_MAX)
                                     lineBreakMode:UILineBreakModeWordWrap];
 
-  return detailTextSize.height + kTableCellVPadding*2;
+  CGSize captionTextSize = [item.caption sizeWithFont:TTSTYLEVAR(tableTitleFont)
+								constrainedToSize:CGSizeMake(kKeyWidth, CGFLOAT_MAX)
+									lineBreakMode:UILineBreakModeTailTruncation];
+	
+  return MAX(detailTextSize.height + kTableCellVPadding*2, captionTextSize.height + kTableCellVPadding*2);
 }
 
 

--- a/src/Three20UI/Sources/TTTableCaptionItemCell.m
+++ b/src/Three20UI/Sources/TTTableCaptionItemCell.m
@@ -78,8 +78,8 @@ static const CGFloat kKeyWidth = 75;
                                     lineBreakMode:UILineBreakModeWordWrap];
 
   CGSize captionTextSize = [item.caption sizeWithFont:TTSTYLEVAR(tableTitleFont)
-								constrainedToSize:CGSizeMake(kKeyWidth, CGFLOAT_MAX)
-									lineBreakMode:UILineBreakModeTailTruncation];
+                                constrainedToSize:CGSizeMake(kKeyWidth, CGFLOAT_MAX)
+                                    lineBreakMode:UILineBreakModeTailTruncation];
 	
   return MAX(detailTextSize.height + kTableCellVPadding*2, captionTextSize.height + kTableCellVPadding*2);
 }


### PR DESCRIPTION
Currently TTTableCaptionItemCell uses only the height of the details text to calculate the cell height. This means the height is incorrectly calculated when the details section is left blank even if it has a caption.

The fix just takes the maximum of the caption or details text height and uses that for the cell height.

Once (if?) this is merged, I'll gladly remove my fork :)
