### PR TITLE
TTURLCache bug

### DIFF
--- a/src/Three20Network/Sources/TTURLCache.m
+++ b/src/Three20Network/Sources/TTURLCache.m
@@ -204,6 +204,9 @@ static NSMutableDictionary* gNamedCaches = nil;
     int pixelCount = image.size.width * image.size.height;
 
     if (force || pixelCount < kLargeImageSize) {
+      if ([_imageCache objectForKey:URL]) {
+        [self removeURL:URL fromDisk:NO];
+      }
       _totalPixelCount += pixelCount;
 
       if (_totalPixelCount > _maxPixelCount && _maxPixelCount) {
@@ -563,6 +566,7 @@ static NSMutableDictionary* gNamedCaches = nil;
   if (image) {
     [_imageSortedList removeObject:oldURL];
     [_imageCache removeObjectForKey:oldURL];
+    [self removeURL:newURL fromDisk:NO];
     [_imageSortedList addObject:newURL];
     [_imageCache setObject:image forKey:newURL];
   }
@@ -598,6 +602,10 @@ static NSMutableDictionary* gNamedCaches = nil;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)removeURL:(NSString*)URL fromDisk:(BOOL)fromDisk {
+  UIImage* existingImage = [_imageCache objectForKey:URL];
+  if (existingImage) {
+    _totalPixelCount -= existingImage.size.width * existingImage.size.height;
+  }
   [_imageSortedList removeObject:URL];
   [_imageCache removeObjectForKey:URL];
 


### PR DESCRIPTION
I was debugging why images just added get expired immediately once you
reach the image cache max pixels. Debugging statements revealed that
although there were no images in the cache map the pixel count was still
just below the max after each expiration.

It seems the problem here is that when storeImage:forURL:force: is
called it's not accounting for the possibility that the image is already
in the cache. It always increments the pixelCount even though there may
already be an image in the dictionary with that key. This causes the
pixelCount to grow higher than it actually is.

This change checks for an existing image in the cache when storing at a
key and decrements the pixel count and removes instances from the sorted
array before continuing to add the new image back to the cache. This ensures
that the pixel count is correct and that there are not duplicates in the
sorted list, while still maintaining the appropriate LRU cache behavior.
