### PR TITLE
Updated StyledTextParser to read the class name from <a> tag

### DIFF
--- a/src/Three20Style/Sources/TTStyledTextParser.m
+++ b/src/Three20Style/Sources/TTStyledTextParser.m
@@ -194,8 +194,8 @@
   } else if ([tag isEqualToString:@"a"]) {
     TTStyledLinkNode* node = [[[TTStyledLinkNode alloc] init] autorelease];
     node.URL =  [attributeDict objectForKey:@"href"];
+    node.className =  [attributeDict objectForKey:@"class"];
     [self pushNode:node];
-
   } else if ([tag isEqualToString:@"button"]) {
     TTStyledButtonNode* node = [[[TTStyledButtonNode alloc] init] autorelease];
     node.URL =  [attributeDict objectForKey:@"href"];


### PR DESCRIPTION
This was pretty much copied from somebody else's fix, on the mailing list if I remember correctly, but unfortunately I cannot recall who it was, to give credit to him.
