### PR TITLE
TTStyledLayout and large images

### DIFF
--- a/src/Three20Style/Sources/TTStyledLayout.m
+++ b/src/Three20Style/Sources/TTStyledLayout.m
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 
+// Slightly modified by github.com/jarnoan
+
 #import "Three20Style/TTStyledLayout.h"
 
 // Style
@@ -586,7 +588,15 @@
       // the current line and mark it with a line break
       [self breakLine];
     } else {
-      _width = contentWidth;
+        // I think this check should be done also when there's padding, 
+        // but in my case this is enough -jarnoan
+        if (contentWidth > _width) {
+            imageHeight = ceil(_width * imageHeight / imageWidth);
+            imageWidth = _width;
+            contentWidth = imageWidth;
+            contentHeight = imageHeight;
+        }
+        _width = contentWidth;
     }
   }
 


### PR DESCRIPTION
If an image is wider than the width of the layout, the layout width becomes bigger, which is incorrect in my opinion. This change causes the image to be scaled down to fit the width of the layout. 

This was a quick fix and only works when there is no padding. This was enough for my case, but in general case this would need a bit more work, but I was afraid of touching anything more than I needed to.
