### PR TITLE
TTStyledTextTableItemCell layout fix for margin

### DIFF
--- a/src/Three20UI/Sources/TTStyledTextTableItemCell.m
+++ b/src/Three20UI/Sources/TTStyledTextTableItemCell.m
@@ -74,14 +74,14 @@ static const CGFloat kDisclosureIndicatorWidth = 23;
     item.text.font = TTSTYLEVAR(font);
   }
 
-  CGFloat padding = [tableView tableCellMargin]*2 + item.padding.left + item.padding.right;
+  CGFloat padding = [tableView tableCellMargin]*2 + item.padding.left + item.padding.right + item.margin.left + item.margin.right;
   if (item.URL) {
     padding += kDisclosureIndicatorWidth;
   }
 
   item.text.width = tableView.width - padding;
 
-  return item.text.height + item.padding.top + item.padding.bottom;
+  return item.text.height + item.padding.top + item.padding.bottom + item.margin.top + item.margin.bottom;
 }
 
 
@@ -96,7 +96,7 @@ static const CGFloat kDisclosureIndicatorWidth = 23;
   [super layoutSubviews];
 
   TTTableStyledTextItem* item = self.object;
-  _label.frame = CGRectOffset(self.contentView.bounds, item.margin.left, item.margin.top);
+  _label.frame = UIEdgeInsetsInsetRect(self.contentView.bounds, item.margin);
 }
 
 


### PR DESCRIPTION
TTStyledTextTableItemCell didn't use margin for width calculations correctly, and this should fix that, I think.
