### PR TITLE
Small change

### DIFF
--- a/src/Three20UI/Sources/TTPhotoView.m
+++ b/src/Three20UI/Sources/TTPhotoView.m
@@ -277,7 +277,16 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (BOOL)loadPreview:(BOOL)fromNetwork {
-  if (![self loadVersion:TTPhotoVersionLarge fromNetwork:NO]) {
+	BOOL keepTrying = YES;
+	// Trying to load the large image first causes scrolling to stall something
+	// fierce when using local images on older iPhones since the large image
+	// *always* starts to load in time for this first call to succeed. So we
+	// skip straight to attempting to load the small version unless we're loading
+	// off the network.
+	if (fromNetwork) {
+		keepTrying = [self loadVersion:TTPhotoVersionLarge fromNetwork:NO];
+	}
+	if (keepTrying) {
     if (![self loadVersion:TTPhotoVersionSmall fromNetwork:NO]) {
       if (![self loadVersion:TTPhotoVersionThumbnail fromNetwork:fromNetwork]) {
         return NO;


### PR DESCRIPTION
Hey Jeff,

Sorry for the delay in getting back to you. Congrats on what's looking like an awesome bugweek so far.

Anyway, here's the only real work I did that's worth merging in before I delete my fork. To give you some context, I used three20 for a client whose app included hundreds of images stored directly in the app. To my surprise, performance with pre-loaded images was far worse than remote-loaded images. This fixes that...hopefully without breaking anything from someone else's perspective.

Cheers,
Chris
