### PR TITLE
AutoresizeForKeyboard behaviour. 

### DIFF
--- a/src/Three20UI/Sources/TTTableViewController.m
+++ b/src/Three20UI/Sources/TTTableViewController.m
@@ -312,7 +312,7 @@ static const CGFloat kBannerViewHeight = 22;
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-- (void)keyboardDidAppear:(BOOL)animated withBounds:(CGRect)bounds {
+- (void) keyboardWillAppear:(BOOL)animated withBounds:(CGRect)bounds {
   [super keyboardDidAppear:animated withBounds:bounds];
   self.tableView.frame = TTRectContract(self.tableView.frame, 0, bounds.size.height);
   [self.tableView scrollFirstResponderIntoView];

--- a/src/Three20UI/Sources/UITableViewAdditions.m
+++ b/src/Three20UI/Sources/UITableViewAdditions.m
@@ -108,7 +108,7 @@
     NSIndexPath* indexPath = [self indexPathForCell:cell];
     if (indexPath) {
       [self scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionMiddle
-            animated:YES];
+            animated:NO];
     }
   }
 }


### PR DESCRIPTION
hen I click on my TTTextEditor thats in a tableview cell it brings up 
the keyboard, it scrolls properly and then sometimes (and only 
sometimes!) the tableview resets back down so the keyboard once again 
obscures the view. 

Discussed in: http://groups.google.com/group/three20/browse_thread/thread/9d8d99c7616866c4
