### PR TITLE
[Network] TTURLRequestLoader: Processing response data when an error occurs

### DIFF
--- a/src/Three20Network/Headers/TTURLRequestQueueInternal.h
+++ b/src/Three20Network/Headers/TTURLRequestQueueInternal.h
@@ -33,7 +33,10 @@
 - (void)               loader:(TTRequestLoader*)loader
     didLoadUnmodifiedResponse:(NSHTTPURLResponse*)response;
 
-- (void)loader:(TTRequestLoader*)loader didFailLoadWithError:(NSError*)error;
+- (void)          loader: (TTRequestLoader*)loader
+    didFailLoadWithError: (NSError*)error
+                response: (NSHTTPURLResponse*)response
+                    data: (id)data;
 - (void)loaderDidCancel:(TTRequestLoader*)loader wasLoading:(BOOL)wasLoading;
 
 @end

--- a/src/Three20Network/Sources/TTRequestLoader.m
+++ b/src/Three20Network/Sources/TTRequestLoader.m
@@ -163,8 +163,9 @@ static const NSInteger kLoadMaxRetries = 2;
 
     TT_RELEASE_SAFELY(_responseData);
     TT_RELEASE_SAFELY(_connection);
+    
+    [_queue loader:self didFailLoadWithError:error response:(NSHTTPURLResponse*)response data:data];
 
-    [_queue loader:self didFailLoadWithError:error];
   } else {
     [self connection:nil didReceiveResponse:(NSHTTPURLResponse*)response];
     [self connection:nil didReceiveData:data];
@@ -337,7 +338,7 @@ static const NSInteger kLoadMaxRetries = 2;
                     _response.statusCode, _urlPath);
     NSError* error = [NSError errorWithDomain:NSURLErrorDomain code:_response.statusCode
                                      userInfo:nil];
-    [_queue loader:self didFailLoadWithError:error];
+    [_queue loader:self didFailLoadWithError:error response:_response data:_responseData];
   }
 
   TT_RELEASE_SAFELY(_responseData);
@@ -359,18 +360,21 @@ didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge{
 
   TTNetworkRequestStopped();
 
-  TT_RELEASE_SAFELY(_responseData);
-  TT_RELEASE_SAFELY(_connection);
-
   if ([error.domain isEqualToString:NSURLErrorDomain] && error.code == NSURLErrorCannotFindHost
       && _retriesLeft) {
+    TT_RELEASE_SAFELY(_responseData);
+    TT_RELEASE_SAFELY(_connection);
+    
     // If there is a network error then we will wait and retry a few times in case
     // it was just a temporary blip in connectivity.
     --_retriesLeft;
     [self load:[NSURL URLWithString:_urlPath]];
 
   } else {
-    [_queue loader:self didFailLoadWithError:error];
+    [_queue loader:self didFailLoadWithError:error response:_response data:_responseData];
+    
+    TT_RELEASE_SAFELY(_responseData);
+    TT_RELEASE_SAFELY(_connection);
   }
 }
 


### PR DESCRIPTION
Sometimes a server returns response with an error (> 400) and a detailed description of the error in data part of the response. But TTURLRequestLoader does not process received data when error code is greater than or equal to 400.
