### PR TITLE
Fix for #338 - Make TTStyledTextLabel use the correct font when rendering bold and italic text.

### DIFF
--- a/samples/TTCatalog/Classes/StyledTextTestController.m
+++ b/samples/TTCatalog/Classes/StyledTextTestController.m
@@ -115,6 +115,18 @@ Both line break characters\n\nand HTML line breaks<br/>are respected.";
   //label1.backgroundColor = [UIColor grayColor];
   [label1 sizeToFit];
   [self.view addSubview:label1];
+  
+  NSString *kText2 = @"You can <i>use</i> <b>other</b> fonts, too.";
+  
+  TTStyledTextLabel* label2 = [[[TTStyledTextLabel alloc] initWithFrame:self.view.bounds] autorelease];
+  label2.font = [UIFont fontWithName:@"Georgia" size:17];
+  label2.text = [TTStyledText textFromXHTML:kText2 lineBreaks:YES URLs:YES];
+  label2.contentInset = UIEdgeInsetsMake(10, 10, 10, 10);
+  [label2 sizeToFit];
+  [self.view addSubview:label2];
+  
+  label2.top = label1.bottom;
+  
 }
 
 @end

--- a/src/Three20Style/Headers/UIFontAdditions.h
+++ b/src/Three20Style/Headers/UIFontAdditions.h
@@ -30,4 +30,22 @@
  */
 - (CGFloat)ttLineHeight;
 
+/**
+ * Returns the bold version of this font, or the same font
+ * if no bold version is available.
+ */
+- (UIFont *)ttBoldVersion;
+
+/**
+ * Returns the italic version of this font, or the same font
+ * if no italic version is available.
+ */
+- (UIFont *)ttItalicVersion;
+
+/**
+ * Returns the normal version of this font.
+ */
+- (UIFont *)ttNormalVersion;
+
+
 @end

--- a/src/Three20Style/Sources/TTStyledLayout.m
+++ b/src/Three20Style/Sources/TTStyledLayout.m
@@ -98,15 +98,13 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (UIFont*)boldVersionOfFont:(UIFont*)font {
-  // XXXjoe Clearly this doesn't work if your font is not the system font
-  return [UIFont boldSystemFontOfSize:font.pointSize];
+  return [font ttBoldVersion];
 }
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (UIFont*)italicVersionOfFont:(UIFont*)font {
-  // XXXjoe Clearly this doesn't work if your font is not the system font
-  return [UIFont italicSystemFontOfSize:font.pointSize];
+  return [font ttItalicVersion];
 }
 
 

--- a/src/Three20Style/Sources/UIFontAdditions.m
+++ b/src/Three20Style/Sources/UIFontAdditions.m
@@ -20,6 +20,11 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////////////
+
+static BOOL TTFontTableIsInitialized = NO;
+static NSDictionary *TTFontTable = nil;
+static NSMutableDictionary *TTFontNameToBaseFont = nil;
+
 /**
  * Additions.
  */
@@ -29,6 +34,142 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (CGFloat)ttLineHeight {
   return (self.ascender - self.descender) + 1;
+}
+
+- (NSDictionary *)dictionaryWithNormal:(NSString *)normalName
+                                  bold:(NSString *)boldName
+                                italic:(NSString *)italicName
+                         boldAndItalic:(NSString *)boldAndItalicName {
+  
+  NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithCapacity:4];
+  
+  if (normalName != nil) {
+    [dict setObject:normalName forKey:@"normal"];
+  }
+  
+  if (boldName != nil) {
+    [dict setObject:boldName forKey:@"bold"];
+  }
+  
+  if (italicName != nil) {
+    [dict setObject:italicName forKey:@"italic"];
+  }
+  
+  if (boldAndItalicName != nil) {
+    [dict setObject:boldAndItalicName forKey:@"boldAndItalic"];
+  }
+  
+  return dict;
+}
+
+- (void)ttInitFontTable {
+  if (TTFontTableIsInitialized) {
+    return;
+  }
+      
+  TTFontTable = [[NSDictionary dictionaryWithObjectsAndKeys:
+                  [self dictionaryWithNormal:@"AmericanTypewriter"
+                                        bold:@"AmericanTypewriter-Bold"
+                                      italic:nil
+                               boldAndItalic:nil],
+                  @"AmericanTypewriter",
+                  [self dictionaryWithNormal:@"Georgia"
+                                        bold:@"Georgia-Bold"
+                                      italic:@"Georgia-Italic"
+                               boldAndItalic:@"Georgia-BoldItalic"],
+                  @"Georgia",
+                  [self dictionaryWithNormal:@"ArialMT"
+                                        bold:@"Arial-BoldMT"
+                                      italic:@"Arial-ItalicMT"
+                               boldAndItalic:@"Arial-BoldItalicMT"],
+                  @"ArialMT",
+                  [self dictionaryWithNormal:@"Courier"
+                                        bold:@"Courier-Bold"
+                                      italic:@"Courier-Oblique"
+                               boldAndItalic:@"Courier-BoldOblique"],
+                  @"Courier",
+                  [self dictionaryWithNormal:@"CourierNewPSMT"
+                                        bold:@"CourierNewPS-BoldMT"
+                                      italic:@"CourierNewPS-ItalicMT"
+                               boldAndItalic:@"CourierNewPS-BoldItalicMT"],
+                  @"CourierNewPSMT",
+                  [self dictionaryWithNormal:@"Helvetica"
+                                        bold:@"Helvetica-Bold"
+                                      italic:@"Helvetica-Oblique"
+                               boldAndItalic:@"Helvetica-BoldOblique"],
+                  @"Helvetica",
+                  [self dictionaryWithNormal:@"HelveticaNeue"
+                                        bold:@"HelveticaNeue-Bold"
+                                      italic:nil
+                               boldAndItalic:nil],
+                  @"HelveticaNeue",
+                  [self dictionaryWithNormal:@"TimesNewRomanPSMT"
+                                        bold:@"TimesNewRomanPS-BoldMT"
+                                      italic:@"TimesNewRomanPS-ItalicMT"
+                               boldAndItalic:@"TimesNewRomanPS-BoldItalicMT"],
+                  @"TimesNewRomanPSMT",
+                  [self dictionaryWithNormal:@"TrebuchetMS"
+                                        bold:@"TrebuchetMS-Bold"
+                                      italic:@"TrebuchetMS-Italic"
+                               boldAndItalic:@"Trebuchet-BoldItalic"],
+                  @"TrebuchetMS",
+                  [self dictionaryWithNormal:@"Verdana"
+                                        bold:@"Verdana-Bold"
+                                      italic:@"Verdana-Italic"
+                               boldAndItalic:@"Verdana-BoldItalic"],
+                  @"Verdana",
+                  nil] retain];
+
+  // Build a mapping of every mode specific font name (e.g. Georgia-Bold)
+  // to the base name (e.g. Georgia)
+  TTFontNameToBaseFont = [[NSMutableDictionary dictionary] retain];
+  
+  for (NSString *baseFontName in [TTFontTable allKeys]) {
+    NSDictionary *fontModes = [TTFontTable objectForKey:baseFontName];
+    for (NSString *modeFontName in [fontModes allValues]) {
+      [TTFontNameToBaseFont setObject:baseFontName forKey:modeFontName];
+    }
+  }
+   
+  TTFontTableIsInitialized = YES;
+}
+
+- (UIFont *)ttFontWithVersion:(NSString *)version {
+  NSString *baseFontName = [TTFontNameToBaseFont objectForKey:self.fontName];
+  
+  if (baseFontName != nil) {
+    NSString *modeFontName = [[TTFontTable objectForKey:baseFontName] objectForKey:version];
+    
+    if (modeFontName != nil) {
+      return [UIFont fontWithName:modeFontName size:self.pointSize];
+    }
+  }
+  
+  return self;
+}
+
+- (UIFont *)ttBoldVersion {
+  if (!TTFontTableIsInitialized) {
+    [self ttInitFontTable];
+  }
+
+  return [self ttFontWithVersion:@"bold"];
+}
+
+- (UIFont *)ttItalicVersion {
+  if (!TTFontTableIsInitialized) {
+    [self ttInitFontTable];
+  }
+  
+  return [self ttFontWithVersion:@"italic"];
+}
+
+- (UIFont *)ttNormalVersion {
+  if (!TTFontTableIsInitialized) {
+    [self ttInitFontTable];
+  }
+  
+  return [self ttFontWithVersion:@"normal"];
 }
 
 @end


### PR DESCRIPTION
This is to make sure <i>some text</i> uses the italic version of whatever font the TTStyledTextLabel is supposed to use, and likewise for bold text.  Previously, it would just always use the [italic|bold]SystemFont.

Included in here is a table of iOS fonts and the specific font names for the the bold, italic, and bold & italic versions.  Not all fonts are listed - just the ones with multiple versions.

The original issue:
https://github.com/facebook/three20/issues/issue/338
