### PR TITLE
TTStyledTextLabel - Some text isn't being aligned on the same baseline as other text.

### DIFF
--- a/src/Three20Style/Sources/TTStyledLayout.m
+++ b/src/Three20Style/Sources/TTStyledLayout.m
@@ -740,7 +740,7 @@
                                   lineBreakMode:UILineBreakModeWordWrap];
 
         [self addFrameForText:lines element:element node:textNode width:linesSize.width
-             height:linesSize.height];
+             height:_lineHeight ? _lineHeight : [_font ttLineHeight]];
         _height += linesSize.height;
         break;
       }
@@ -757,7 +757,7 @@
         frameWidth = [[text substringWithRange:NSMakeRange(frameStart, stringIndex - frameStart)]
                       sizeWithFont:_font].width;
         [self addFrameForText:line element:element node:textNode width:frameWidth
-              height:[_font ttLineHeight]];
+              height:_lineHeight ? _lineHeight : [_font ttLineHeight]];
         frameWidth = 0;
       }
     }

--- a/src/Three20Style/Sources/TTStyledLayout.m
+++ b/src/Three20Style/Sources/TTStyledLayout.m
@@ -740,7 +740,7 @@
                                   lineBreakMode:UILineBreakModeWordWrap];
 
         [self addFrameForText:lines element:element node:textNode width:linesSize.width
-             height:_lineHeight ? _lineHeight : [_font ttLineHeight]];
+             height:linesSize.height];
         _height += linesSize.height;
         break;
       }


### PR DESCRIPTION
See this screenshot to understand the issue (look for the funky alignments):
http://fpotter_public.s3.amazonaws.com/bad_font_size_16.png

You'll notice I'm not using Helvetica, which is I think the reason I came across this issue in the first place.  Helvetica just seems to work.  And, I'm also using bold and italic text in non-Helvetica fonts, which is enabled by this change: https://github.com/facebook/three20/pull/339

The issue is is in `TTStyledLayout.m`, in `layoutText:container:`.  There are five places in there where `addFrameForText` gets called, and in most cases the height for the frame is taken from the `_lineHeight` variable.  If we change the last case to use `_lineHeight` as well, things start working.  I wonder if this was just an accidental omission?

To go deeper...

You would think it would just work as-is.  `_lineHeight` should be equal to `[font ttLineHeight]` but they're not for at least some fonts and point sizes.  For example, in the case I was debugging, `_lineHeight` was 20.0 but `[font ttLineHeight]` was 19.57..something.  And, when ttLineHeight is less than `_lineHeight`, TTStyledLayout tries to compensate by adding in offsets in `breakLine`, but it adds the wrong offsets.

See....

```
if (_lineFirstFrame.nextFrame) {
  TTStyledFrame* frame = _lineFirstFrame;
  while (frame) {
    // Align to the text baseline
    // XXXjoe Support top, bottom, and center alignment also
    if (frame.height < _lineHeight) {
      UIFont* font = frame.font ? frame.font : _font;
      [self offsetFrame:frame by:(_lineHeight - (frame.height - font.descender))];         
    }
    frame = frame.nextFrame;
  }
}
```

I'm still a little confused, but my bug is fixed :-)  Feedback welcome!
