### PR TITLE
Fix TTStyledLayout bug: Baseline of styled text is incorrect

### DIFF
--- a/src/Three20Style/Sources/TTStyledLayout.m
+++ b/src/Three20Style/Sources/TTStyledLayout.m
@@ -336,13 +336,27 @@
 
   // Vertically align all frames on the current line
   if (_lineFirstFrame.nextFrame) {
-    TTStyledFrame* frame = _lineFirstFrame;
+    TTStyledFrame* frame;
+
+    // Find the descender that descends the farthest below the baseline.
+    // font.descender is a negative number if the descender descends below
+    // the baseline (as most descenders do), but can also be a positive
+    // number for a descender above the baseline.
+    CGFloat lowestDescender = MAXFLOAT;
+    frame = _lineFirstFrame;
+    while (frame) {
+      UIFont* font = frame.font ? frame.font : _font;
+      lowestDescender = MIN(lowestDescender, font.descender);
+      frame = frame.nextFrame;
+    }
+
+    frame = _lineFirstFrame;
     while (frame) {
       // Align to the text baseline
       // XXXjoe Support top, bottom, and center alignment also
       if (frame.height < _lineHeight) {
         UIFont* font = frame.font ? frame.font : _font;
-        [self offsetFrame:frame by:(_lineHeight - (frame.height - font.descender))];
+        [self offsetFrame:frame by:(_lineHeight - (frame.height - (lowestDescender - font.descender)))];
       }
       frame = frame.nextFrame;
     }


### PR DESCRIPTION
This is the first of two pull requests I'll be submitting related to the baseline of styled text.

When a line of styled text has fonts of different sizes, the baseline of the text isn't aligned correctly.  It's close, but definitely not quite right.  To see what I mean, see https://github.com/mmorearty/three20-baseline-bug -- you can either just look at the screenshots I put there, or download and compile the app yourself.  The issue I'm logging here is what is referred to as the "first baseline bug" in the sample app and screenshots.  **Important:** If you want to compile the sample app, you'll need to link it to the Three20 library -- see the [README.md](https://github.com/mmorearty/three20-baseline-bug/blob/master/README.md) file.

This is caused by the fact that when TTStyledLayout is laying out styled text, it uses an incorrect algorithm to align the baselines.  This patch fixes the algorithm.

I'm targeting the "v1.0" branch with this pull request.  For future reference, do you want people to target v1.0, or master?
