### PR TITLE
Fix TTStyledLayout bug: Baseline of styled text is incorrect when text wraps

### DIFF
--- a/src/Three20Style/Sources/TTStyledLayout.m
+++ b/src/Three20Style/Sources/TTStyledLayout.m
@@ -683,7 +683,7 @@
             frameWidth = [[text substringWithRange:NSMakeRange(frameStart, stringIndex - frameStart)]
                           sizeWithFont:_font].width;
             [self addFrameForText:line element:element node:textNode width:frameWidth
-                  height:_lineHeight ? _lineHeight : [_font ttLineHeight]];
+                  height:[_font ttLineHeight]];
           }
 
           if (_lineWidth) {
@@ -705,7 +705,7 @@
         frameWidth = [[text substringWithRange:NSMakeRange(frameStart, stringIndex - frameStart)]
                       sizeWithFont:_font].width;
         [self addFrameForText:line element:element node:textNode width:frameWidth
-              height:_lineHeight ? _lineHeight : [_font ttLineHeight]];
+              height:[_font ttLineHeight]];
 
         lineStartIndex = lineRange.location + lineRange.length;
         frameStart = stringIndex;
@@ -720,7 +720,7 @@
           frameWidth = [[text substringWithRange:NSMakeRange(frameStart, stringIndex - frameStart)]
                         sizeWithFont:_font].width;
           [self addFrameForText:line element:element node:textNode width:frameWidth
-                height:_lineHeight ? _lineHeight : [_font ttLineHeight]];
+                height:[_font ttLineHeight]];
         }
 
         if (_lineWidth) {


### PR DESCRIPTION
This is the second of two pull requests I'm submitting related to the baseline of styled text.  The first one was facebook/three20#377.

When a line of styled text has fonts of different sizes, if the text wraps onto the next line, then the baseline of the last chunk of text on the first line isn't aligned correctly.  To see what I mean, see https://github.com/mmorearty/three20-baseline-bug -- you can either just look at the screenshots I put there, or download and compile the app yourself.  The issue I'm logging here is what is referred to as the "second baseline bug" in the sample app and screenshots.  **Important:** If you want to compile the sample app, you'll need to link it to the Three20 library -- see the [README.md](https://github.com/mmorearty/three20-baseline-bug/blob/master/README.md) file.

[This](https://github.com/facebook/three20/pull/340#issuecomment-655418) earlier comment by me offers a little peek into the history of this.  For some reason that isn't clear, long ago several places in the code changed `height:[_font ttLineHeight]` to `height:_lineHeight ? _lineHeight : [_font ttLineHeight]`.  I can't figure out why it was done, and I think it might have been a mistake; in fact, one of those changes was backed out.  This patch I'm proposing backs out the rest of them, which fixes the baseline alignment problems.
