### PR TITLE
Bug with height calculation of TTTableSubtextItem in grouped table

### DIFF
--- a/src/Three20UI/Sources/TTTableSubtextItemCell.m
+++ b/src/Three20UI/Sources/TTTableSubtextItemCell.m
@@ -17,7 +17,8 @@
 #import "Three20UI/TTTableSubtextItemCell.h"
 
 // UI
-#import "Three20UI/TTTableCaptionItem.h"
+#import "Three20UI/TTTableSubtextItem.h"
+#import "Three20UI/UITableViewAdditions.h"
 #import "Three20UI/UIViewAdditions.h"
 
 // Style
@@ -60,9 +61,9 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 + (CGFloat)tableView:(UITableView*)tableView rowHeightForObject:(id)object {
-  TTTableCaptionItem* item = object;
+  TTTableSubtextItem* item = object;
 
-  CGFloat width = tableView.width - kTableCellHPadding*2;
+  CGFloat width = tableView.width - [tableView tableCellMargin]*2 - kTableCellHPadding*2;
 
   CGSize detailTextSize = [item.text sizeWithFont:TTSTYLEVAR(tableFont)
                                 constrainedToSize:CGSizeMake(width, CGFLOAT_MAX)
@@ -120,7 +121,7 @@
   if (_item != object) {
     [super setObject:object];
 
-    TTTableCaptionItem* item = object;
+    TTTableSubtextItem* item = object;
     self.textLabel.text = item.caption;
     self.detailTextLabel.text = item.text;
   }


### PR DESCRIPTION
Patch for an issue reported in [this discussion](https://groups.google.com/d/topic/three20/kLyUpw-OP6A/discussion): If you have a TTTableSubtextItem in a table that has the "grouped" style, the height of the TTTableSubtextItem is calculated incorrectly: ![screenshot](http://www.puc.edu/__data/assets/image/0011/78806/Screen-shot-2011-02-01-at-11.33.00-AM.png)
