### PR TITLE
Improved URL encoding for stringByAddingQueryDictionary:

### DIFF
--- a/src/Three20Core/Headers/NSStringAdditions.h
+++ b/src/Three20Core/Headers/NSStringAdditions.h
@@ -46,7 +46,16 @@
 - (NSDictionary*)queryContentsUsingEncoding:(NSStringEncoding)encoding;
 
 /**
- * Parses a URL, adds query parameters to its query, and re-encodes it as a new URL.
+ * Returns a string will all non-ASCII characters, reserved characters for URIs (;/?:@&=+$,),
+ * and a few other trouble characters (!'()*\n\"<># \t) replaced with escape sequences using
+ * percent encoding. Strings returned by this method should be safe to be used as any URI
+ * component, including query parameters.
+ */
+- (NSString*)stringByEncodingAsURL;
+
+/**
+ * Parses a URL, adds query parameters to its query, and re-encodes it as a new URL. Both
+ * keys and values in the query dictionary are encoded using -stringByEncodingAsURL.
  */
 - (NSString*)stringByAddingQueryDictionary:(NSDictionary*)query;
 

--- a/src/Three20Core/Sources/NSStringAdditions.m
+++ b/src/Three20Core/Sources/NSStringAdditions.m
@@ -108,13 +108,20 @@
   return [NSDictionary dictionaryWithDictionary:pairs];
 }
 
+- (NSString*)stringByEncodingAsURL
+{
+    CFStringRef str = CFURLCreateStringByAddingPercentEscapes(NULL, (CFStringRef) self, NULL,
+                        CFSTR("=,!$&'()*+;@?\n\"<>#\t :/"), kCFStringEncodingUTF8);
+    return [((NSString *) str) autorelease];
+}
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (NSString*)stringByAddingQueryDictionary:(NSDictionary*)query {
   NSMutableArray* pairs = [NSMutableArray array];
   for (NSString* key in [query keyEnumerator]) {
     NSString* value = [query objectForKey:key];
-    value = [value stringByReplacingOccurrencesOfString:@"?" withString:@"%3F"];
-    value = [value stringByReplacingOccurrencesOfString:@"=" withString:@"%3D"];
+    key = [key stringByEncodingAsURL];
+    value = [value stringByEncodingAsURL];
     NSString* pair = [NSString stringWithFormat:@"%@=%@", key, value];
     [pairs addObject:pair];
   }


### PR DESCRIPTION
Currently, -stringByAddingQueryDictionary: only performs two simple substitutions before returning the new string.

Since I believe the output of this method will should more than likely be used to construct URIs, further escaping is needed to account for non-ASCII characters and a number of reserved characters that shouldn't be used in URIs.

This commit adds a new method to NSString(TTAdditions) to perform such escaping, and uses the new method from -stringByAddingQueryDictionary:.
