### PR TITLE
set rootViewController of window

### DIFF
--- a/src/Three20UINavigator/Sources/TTBaseNavigator.m
+++ b/src/Three20UINavigator/Sources/TTBaseNavigator.m
@@ -241,6 +241,10 @@ UIKIT_EXTERN NSString *const UIApplicationWillEnterForegroundNotification __attr
 
     } else {
       [self.window addSubview:_rootViewController.view];
+
+      // HACK added by PS
+      // set window's rootViewController to current set one
+      self.window.rootViewController = controller;
     }
   }
 }


### PR DESCRIPTION
THIS IS JUST AN INSPIRATION

I believe the UIWindow's rootViewController should be set by TTNavigator automatically.
This is a one-line-attempt to fix that.

If three20 wants to stay 3.x compatible you should add respondsToSelector to the call (also, remove my hack comment) 
