### PR TITLE
fix table overlay view to use full size of the controller window

### DIFF
--- a/src/Three20UI/Sources/TTTableViewController.m
+++ b/src/Three20UI/Sources/TTTableViewController.m
@@ -140,7 +140,7 @@
     _tableOverlayView = [[UIView alloc] initWithFrame:frame];
     _tableOverlayView.autoresizesSubviews = YES;
     _tableOverlayView.autoresizingMask = UIViewAutoresizingFlexibleWidth
-    | UIViewAutoresizingFlexibleBottomMargin;
+    | UIViewAutoresizingFlexibleHeight;
     NSInteger tableIndex = [_tableView.superview.subviews indexOfObject:_tableView];
     if (tableIndex != NSNotFound) {
       [_tableView.superview addSubview:_tableOverlayView];


### PR DESCRIPTION
Prior the change, there was an "empty gap" when showing the no pictures screen and using a uitabbar.
