### PR TITLE
More flexibility for a TTTableViewDataSource to map item to cell classes

### DIFF
--- a/src/Three20UI/Headers/TTTableViewDataSource.h
+++ b/src/Three20UI/Headers/TTTableViewDataSource.h
@@ -30,6 +30,8 @@
 
 - (id)tableView:(UITableView*)tableView objectForRowAtIndexPath:(NSIndexPath*)indexPath;
 
+- (void)setCellClass:(NSString*)cellClass forItemClass:(NSString*)itemClass;
+
 - (Class)tableView:(UITableView*)tableView cellClassForObject:(id)object;
 
 - (NSString*)tableView:(UITableView*)tableView labelForObject:(id)object;
@@ -79,6 +81,7 @@
 
 @interface TTTableViewDataSource : NSObject <TTTableViewDataSource> {
   id<TTModel> _model;
+  NSMutableDictionary * _itemCellClassMapping;
 }
 
 @end

--- a/src/Three20UI/Sources/TTTableViewDataSource.m
+++ b/src/Three20UI/Sources/TTTableViewDataSource.m
@@ -69,6 +69,7 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)dealloc {
   TT_RELEASE_SAFELY(_model);
+  TT_RELEASE_SAFELY(_itemCellClassMapping);
 
   [super dealloc];
 }
@@ -243,10 +244,22 @@
   return nil;
 }
 
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)setCellClass:(NSString*)cellClass forItemClass:(NSString*)itemClass {
+  if(!_itemCellClassMapping) {
+    _itemCellClassMapping = [[NSMutableDictionary alloc] init];
+  }
+  [_itemCellClassMapping setObject:cellClass forKey:itemClass];
+}
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (Class)tableView:(UITableView*)tableView cellClassForObject:(id)object {
-  if ([object isKindOfClass:[TTTableItem class]]) {
+  if ([object respondsToSelector:@selector(cellClass)])
+    return [object cellClass];
+  else if(_itemCellClassMapping && [_itemCellClassMapping objectForKey:NSStringFromClass([object class])]) {
+    return NSClassFromString([_itemCellClassMapping objectForKey:NSStringFromClass([object class])]);
+  }
+  else if ([object isKindOfClass:[TTTableItem class]]) {
     if ([object isKindOfClass:[TTTableMoreButton class]]) {
       return [TTTableMoreButtonCell class];
     } else if ([object isKindOfClass:[TTTableSubtextItem class]]) {


### PR DESCRIPTION
- The individual item objects can understand their cell representation class, avoiding the need for a subclass of TTTableViewDataSource
- The constructor of a datasource can specify mapping, obviating need for a custom datasource class or even a tableitem class at all

This DRYs up client code quite a bit.  Acceptance to the upstream will make my rebases easier. ;-)
