### PR TITLE
Fix TTPostController showInView:animated: to call superController's viewWillDisappear: and viewDidDisappear: methods.

### DIFF
--- a/src/Three20UI/Sources/TTPostController.m
+++ b/src/Three20UI/Sources/TTPostController.m
@@ -367,6 +367,7 @@ static const CGFloat kMarginY = 6;
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)showInView:(UIView*)view animated:(BOOL)animated {
   [self retain];
+  [self.superController viewWillDisappear:animated];
   UIWindow* window = view.window ? view.window : [UIApplication sharedApplication].keyWindow;
 
   self.view.transform = [self transformForOrientation];
@@ -422,7 +423,7 @@ static const CGFloat kMarginY = 6;
     [self layoutTextEditor];
     [self showAnimationDidStop];
   }
-
+  [self.superController viewDidDisappear:animated];
   [self showKeyboard];
 }
 


### PR DESCRIPTION
TTPostController should call the parent view's viewWillDisappear: and viewDidDisappear: methods when showInView:animated: is invoked.
