### PR TITLE
TTLauncherButton add support for badge text to be ! if badgeNumber is NSNotFound.

### DIFF
--- a/src/Three20UI/Sources/TTLauncherButton.m
+++ b/src/Three20UI/Sources/TTLauncherButton.m
@@ -111,7 +111,9 @@ static const NSInteger kMaxBadgeNumber = 99;
     [self addSubview:_badge];
   }
 
-  if (_item.badgeNumber > 0) {
+  if (_item.badgeNumber == NSNotFound) {
+      _badge.text = @"!";
+  } else if (_item.badgeNumber > 0) {
     if (_item.badgeNumber <= kMaxBadgeNumber) {
       _badge.text = [NSString stringWithFormat:@"%d", _item.badgeNumber];
 


### PR DESCRIPTION
If the badgeNumber is set to NSNotFound, the badge text will display as !.  

We use this to indicate an error when a send fails, just like the SMS.app.
