### PR TITLE
Fix to avoid needing -all_load or -force_load linker flags.

### DIFF
--- a/src/Three20Core/Headers/TTCorePreprocessorMacros.h
+++ b/src/Three20Core/Headers/TTCorePreprocessorMacros.h
@@ -25,6 +25,13 @@
  */
 #define __TTDEPRECATED_METHOD __attribute__((deprecated))
 
+/**
+ * Add this macro to the end of each category addition implementation, so we don't have to use -all_load
+ * or -force_load to load object files from static libraries that only contain categories and no classes.
+ * See http://developer.apple.com/library/mac/#qa/qa2006/qa1490.html for more info.
+ */
+#define TT_FIX_CATEGORY_BUG(name) @interface TT_FIX_CATEGORY_BUG_##name @end @implementation TT_FIX_CATEGORY_BUG_##name @end
+
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Flags

--- a/src/Three20Core/Sources/NSArrayAdditions.m
+++ b/src/Three20Core/Sources/NSArrayAdditions.m
@@ -134,3 +134,6 @@
 
 
 @end
+
+#import "Three20Core/TTCorePreprocessorMacros.h"
+TT_FIX_CATEGORY_BUG(NSArrayAdditions)

--- a/src/Three20Core/Sources/NSDataAdditions.m
+++ b/src/Three20Core/Sources/NSDataAdditions.m
@@ -53,3 +53,6 @@
 }
 
 @end
+
+#import "Three20Core/TTCorePreprocessorMacros.h"
+TT_FIX_CATEGORY_BUG(NSDataAdditions)

--- a/src/Three20Core/Sources/NSDateAdditions.m
+++ b/src/Three20Core/Sources/NSDateAdditions.m
@@ -252,3 +252,6 @@
 
 
 @end
+
+#import "Three20Core/TTCorePreprocessorMacros.h"
+TT_FIX_CATEGORY_BUG(NSDateAdditions)

--- a/src/Three20Core/Sources/NSMutableArrayAdditions.m
+++ b/src/Three20Core/Sources/NSMutableArrayAdditions.m
@@ -37,3 +37,6 @@
 
 
 @end
+
+#import "Three20Core/TTCorePreprocessorMacros.h"
+TT_FIX_CATEGORY_BUG(NSMutableArrayAdditions)

--- a/src/Three20Core/Sources/NSMutableDictionaryAdditions.m
+++ b/src/Three20Core/Sources/NSMutableDictionaryAdditions.m
@@ -38,3 +38,6 @@
 
 
 @end
+
+#import "Three20Core/TTCorePreprocessorMacros.h"
+TT_FIX_CATEGORY_BUG(NSMutableDictionaryAdditions)

--- a/src/Three20Core/Sources/NSObjectAdditions.m
+++ b/src/Three20Core/Sources/NSObjectAdditions.m
@@ -161,3 +161,6 @@
 
 
 @end
+
+#import "Three20Core/TTCorePreprocessorMacros.h"
+TT_FIX_CATEGORY_BUG(NSObjectAdditions)

--- a/src/Three20Core/Sources/NSStringAdditions.m
+++ b/src/Three20Core/Sources/NSStringAdditions.m
@@ -174,3 +174,5 @@
 
 @end
 
+#import "Three20Core/TTCorePreprocessorMacros.h"
+TT_FIX_CATEGORY_BUG(NSStringAdditions)

--- a/src/Three20Style/Sources/TTStyleInternal.m
+++ b/src/Three20Style/Sources/TTStyleInternal.m
@@ -63,3 +63,6 @@ const NSInteger kDefaultLightSource = 125;
 
 @end
 
+#import "Three20Core/TTCorePreprocessorMacros.h"
+TT_FIX_CATEGORY_BUG(TTStyleInternal)
+

--- a/src/Three20Style/Sources/TTStyledNodeInternal.m
+++ b/src/Three20Style/Sources/TTStyledNodeInternal.m
@@ -37,3 +37,6 @@
 
 @end
 
+#import "Three20Core/TTCorePreprocessorMacros.h"
+TT_FIX_CATEGORY_BUG(TTStyledNodeInternal)
+

--- a/src/Three20Style/Sources/UIColorAdditions.m
+++ b/src/Three20Style/Sources/UIColorAdditions.m
@@ -210,3 +210,6 @@ void HSVtoRGB( float *r, float *g, float *b, float h, float s, float v ) {
 
 
 @end
+
+#import "Three20Core/TTCorePreprocessorMacros.h"
+TT_FIX_CATEGORY_BUG(UIColorAdditions)

--- a/src/Three20Style/Sources/UIFontAdditions.m
+++ b/src/Three20Style/Sources/UIFontAdditions.m
@@ -32,3 +32,6 @@
 }
 
 @end
+
+#import "Three20Core/TTCorePreprocessorMacros.h"
+TT_FIX_CATEGORY_BUG(UIFontAdditions)

--- a/src/Three20Style/Sources/UIImageAdditions.m
+++ b/src/Three20Style/Sources/UIImageAdditions.m
@@ -229,3 +229,6 @@
 
 
 @end
+
+#import "Three20Core/TTCorePreprocessorMacros.h"
+TT_FIX_CATEGORY_BUG(UIImageAdditions)

--- a/src/Three20UI/Sources/TTImageViewInternal.m
+++ b/src/Three20UI/Sources/TTImageViewInternal.m
@@ -106,3 +106,7 @@
 
 
 @end
+
+
+#import "Three20Core/TTCorePreprocessorMacros.h"
+TT_FIX_CATEGORY_BUG(TTImageViewInternal)

--- a/src/Three20UI/Sources/TTSearchTextFieldInternal.m
+++ b/src/Three20UI/Sources/TTSearchTextFieldInternal.m
@@ -129,3 +129,6 @@
 
 
 @end
+
+#import "Three20Core/TTCorePreprocessorMacros.h"
+TT_FIX_CATEGORY_BUG(TTSearchTextFieldInternal)

--- a/src/Three20UI/Sources/TTTabBarInternal.m
+++ b/src/Three20UI/Sources/TTTabBarInternal.m
@@ -88,3 +88,6 @@ static  CGFloat   kPadding        = 10;
 
 
 @end
+
+#import "Three20Core/TTCorePreprocessorMacros.h"
+TT_FIX_CATEGORY_BUG(TTTabBarInternal)

--- a/src/Three20UI/Sources/TTTextEditorInternal.m
+++ b/src/Three20UI/Sources/TTTextEditorInternal.m
@@ -213,3 +213,6 @@
 
 
 @end
+
+#import "Three20Core/TTCorePreprocessorMacros.h"
+TT_FIX_CATEGORY_BUG(TTTextEditorInternal)

--- a/src/Three20UI/Sources/UINSObjectAdditions.m
+++ b/src/Three20UI/Sources/UINSObjectAdditions.m
@@ -45,3 +45,7 @@
 
 
 @end
+
+
+#import "Three20Core/TTCorePreprocessorMacros.h"
+TT_FIX_CATEGORY_BUG(UINSObjectAdditions)

--- a/src/Three20UI/Sources/UINSStringAdditions.m
+++ b/src/Three20UI/Sources/UINSStringAdditions.m
@@ -56,3 +56,6 @@
 
 
 @end
+
+#import "Three20Core/TTCorePreprocessorMacros.h"
+TT_FIX_CATEGORY_BUG(UINSStringAdditions)

--- a/src/Three20UI/Sources/UINavigationControllerAdditions.m
+++ b/src/Three20UI/Sources/UINavigationControllerAdditions.m
@@ -132,3 +132,7 @@
 
 
 @end
+
+
+#import "Three20Core/TTCorePreprocessorMacros.h"
+TT_FIX_CATEGORY_BUG(UINavigationControllerAdditions)

--- a/src/Three20UI/Sources/UITabBarControllerAdditions.m
+++ b/src/Three20UI/Sources/UITabBarControllerAdditions.m
@@ -122,3 +122,6 @@
 
 
 @end
+
+#import "Three20Core/TTCorePreprocessorMacros.h"
+TT_FIX_CATEGORY_BUG(UITabBarControllerAdditions)

--- a/src/Three20UI/Sources/UITableViewAdditions.m
+++ b/src/Three20UI/Sources/UITableViewAdditions.m
@@ -134,3 +134,6 @@
 
 
 @end
+
+#import "Three20Core/TTCorePreprocessorMacros.h"
+TT_FIX_CATEGORY_BUG(UITableViewAdditions)

--- a/src/Three20UI/Sources/UIToolbarAdditions.m
+++ b/src/Three20UI/Sources/UIToolbarAdditions.m
@@ -53,3 +53,6 @@
 
 
 @end
+
+#import "Three20Core/TTCorePreprocessorMacros.h"
+TT_FIX_CATEGORY_BUG(UIToolbarAdditions)

--- a/src/Three20UI/Sources/UIViewAdditions.m
+++ b/src/Three20UI/Sources/UIViewAdditions.m
@@ -525,3 +525,6 @@
 
 
 @end
+
+#import "Three20Core/TTCorePreprocessorMacros.h"
+TT_FIX_CATEGORY_BUG(UIViewAdditions)

--- a/src/Three20UI/Sources/UIWebViewAdditions.m
+++ b/src/Three20UI/Sources/UIWebViewAdditions.m
@@ -67,3 +67,6 @@
 
 
 @end
+
+#import "Three20Core/TTCorePreprocessorMacros.h"
+TT_FIX_CATEGORY_BUG(UIWebViewAdditions)

--- a/src/Three20UICommon/Sources/UIViewControllerAdditions.m
+++ b/src/Three20UICommon/Sources/UIViewControllerAdditions.m
@@ -378,3 +378,6 @@ static const NSTimeInterval kGarbageCollectionInterval = 20;
 
 
 @end
+
+#import "Three20Core/TTCorePreprocessorMacros.h"
+TT_FIX_CATEGORY_BUG(UIViewControllerAdditions)

--- a/src/Three20UICommon/Sources/UIWindowAdditions.m
+++ b/src/Three20UICommon/Sources/UIWindowAdditions.m
@@ -53,3 +53,6 @@
 
 
 @end
+
+#import "Three20Core/TTCorePreprocessorMacros.h"
+TT_FIX_CATEGORY_BUG(UIWindowAdditions)

--- a/src/Three20UINavigator/Sources/TTURLPatternInternal.m
+++ b/src/Three20UINavigator/Sources/TTURLPatternInternal.m
@@ -33,3 +33,6 @@
 
 @end
 
+#import "Three20Core/TTCorePreprocessorMacros.h"
+TT_FIX_CATEGORY_BUG(TTURLPatternInternal)
+

--- a/src/Three20UINavigator/Sources/UIViewController+TTNavigator.m
+++ b/src/Three20UINavigator/Sources/UIViewController+TTNavigator.m
@@ -189,3 +189,6 @@ static const NSTimeInterval kGarbageCollectionInterval = 20;
 
 
 @end
+
+#import "Three20Core/TTCorePreprocessorMacros.h"
+TT_FIX_CATEGORY_BUG(UIViewController_TTNavigator)

--- a/src/extThree20JSON/Vendors/JSON/NSObject+SBJSON.m
+++ b/src/extThree20JSON/Vendors/JSON/NSObject+SBJSON.m
@@ -42,3 +42,6 @@
 }
 
 @end
+
+#import "Three20Core/TTCorePreprocessorMacros.h"
+TT_FIX_CATEGORY_BUG(NSObject_SBJSON)

--- a/src/extThree20JSON/Vendors/JSON/NSString+SBJSON.m
+++ b/src/extThree20JSON/Vendors/JSON/NSString+SBJSON.m
@@ -43,3 +43,7 @@
 }
 
 @end
+
+
+#import "Three20Core/TTCorePreprocessorMacros.h"
+TT_FIX_CATEGORY_BUG(NSString_SBJSON)

--- a/src/extThree20JSON/Vendors/YAJL/NSObject+YAJL.m
+++ b/src/extThree20JSON/Vendors/YAJL/NSObject+YAJL.m
@@ -77,3 +77,6 @@
 }
 
 @end
+
+#import "Three20Core/TTCorePreprocessorMacros.h"
+TT_FIX_CATEGORY_BUG(NSObject_JAJL)


### PR DESCRIPTION
The changes in this pull request cause the linker to load the object files without the need to use the -all_load or -force_load flags.

We include other libraries that break if we use -all_load.  We also want to avoid using -force_load, so that the libraries will symbolicate properly when we debug.
