### PR TITLE
Hotfix webcontrollerrequests

### DIFF
--- a/src/Three20UI/Sources/TTWebController.m
+++ b/src/Three20UI/Sources/TTWebController.m
@@ -317,7 +317,6 @@
   if (!self.navigationItem.rightBarButtonItem) {
     [self.navigationItem setRightBarButtonItem:_activityItem animated:YES];
   }
-  TTNetworkRequestStarted();
   [_toolbar replaceItemWithTag:3 withItem:_stopButton];
   _backButton.enabled = [_webView canGoBack];
   _forwardButton.enabled = [_webView canGoForward];
@@ -327,7 +326,6 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)webViewDidFinishLoad:(UIWebView*)webView {
   TT_RELEASE_SAFELY(_loadingURL);
-  TTNetworkRequestStopped();
   self.title = [_webView stringByEvaluatingJavaScriptFromString:@"document.title"];
   if (self.navigationItem.rightBarButtonItem == _activityItem) {
     [self.navigationItem setRightBarButtonItem:nil animated:YES];


### PR DESCRIPTION
Adding support for network status isn't as simple as it might seem for this controller. If the controller is popped off the stack, for example, we'll never get enough request stopped messages to stop the indicator, resulting in a permanent loading state for the app.

Barring a proper solution to this problem, for now we'll leave it to the controller to display the fact that it is loading.
