### PR TITLE
TTImageView default image flicker fix

### DIFF
--- a/src/Three20UI/Sources/TTImageView.m
+++ b/src/Three20UI/Sources/TTImageView.m
@@ -209,7 +209,7 @@
 
       if (![request send]) {
         // Put the default image in place while waiting for the request to load
-        if (_defaultImage && self.image != _defaultImage) {
+        if (_defaultImage && nil == self.image) {
           self.image = _defaultImage;
         }
       }


### PR DESCRIPTION
_Note:_ This is not a duplicate - the original (#413) requested that my code be pulled into `master` instead of `development`. I feel like you should change your integration branch to `development` to prevent this sort of thing from happening.

When transitioning from a thumbnail to the large size of an image the reload method was only checking to see (a) whether there was a default image and (b) whether the image was not already the default image before changing it to be the default image. This causes the image view to transition from thumbnail -> default image -> large image which introduces a flicker that was first described in #250. That ticket has a proposed fix which I found to be insufficient (it did fix it but introduced another bug).

It may be that this fix is also insufficient. Maybe I need to include a unit test or maybe I also introduced a bug somewhere I didn't test. If so let me know and I'll fix it. Thanks!
