### PR TITLE
Cache policy

### DIFF
--- a/src/Three20Network/Sources/TTURLImageResponse.m
+++ b/src/Three20Network/Sources/TTURLImageResponse.m
@@ -61,8 +61,9 @@
     // TODO(jverkoey Feb 10, 2010): This logic doesn't entirely make sense. Why don't we just store
     // the data in the cache if there was a cache miss, and then just retain the image data we
     // downloaded? This needs to be tested in production.
-    UIImage* image = [[TTURLCache sharedCache] imageForURL:request.urlPath fromDisk:NO];
-
+	UIImage* image = nil;
+	if(request.cachePolicy != TTURLRequestCachePolicyNoCache)
+      image = [[TTURLCache sharedCache] imageForURL:request.urlPath fromDisk:NO];
     if (nil == image) {
       image = [UIImage imageWithData:data];
     }


### PR DESCRIPTION
This allows an image loader to force an update using cache policy TTURLRequestCachePolicyNoCache

(Useful for advertising banners, where we want to force a new ad to load.)
