### PR TITLE
Support rfc2397 data:// URI schemes

### DIFF
--- a/src/Three20Core/Headers/NSDataAdditions.h
+++ b/src/Three20Core/Headers/NSDataAdditions.h
@@ -32,4 +32,19 @@
  */
 @property (nonatomic, readonly) NSString* sha1Hash;
 
+
+/**
+ * Create an NSData from a base64 encoded representation
+ *
+ * @return the NSData object
+ */
++ (id)dataWithBase64EncodedString:(NSString *)string;     //  Padding '=' characters are optional. Whitespace is ignored.
+
+/**
+ * Marshal the data into a base64 encoded representation
+ *
+ * @return the base64 encoded string
+ */
+- (NSString *)base64Encoding;
+
 @end

--- a/src/Three20Core/Sources/NSDataAdditions.m
+++ b/src/Three20Core/Sources/NSDataAdditions.m
@@ -52,4 +52,104 @@
   ];
 }
 
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// base64 code found on http://www.cocoadev.com/index.pl?BaseSixtyFour
+// where the poster released it to public domain
+static const char encodingTable[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
++ (id)dataWithBase64EncodedString:(NSString *)string;
+{
+  if ([string length] == 0)
+    return [NSData data];
+
+  static char *decodingTable = NULL;
+  if (decodingTable == NULL)
+  {
+    decodingTable = malloc(256);
+    if (decodingTable == NULL)
+      return nil;
+    memset(decodingTable, CHAR_MAX, 256);
+    NSUInteger i;
+    for (i = 0; i < 64; i++)
+      decodingTable[(short)encodingTable[i]] = i;
+  }
+
+  const char *characters = [string cStringUsingEncoding:NSASCIIStringEncoding];
+  if (characters == NULL)     //  Not an ASCII string!
+    return nil;
+  char *bytes = malloc((([string length] + 3) / 4) * 3);
+  if (bytes == NULL)
+    return nil;
+  NSUInteger length = 0;
+
+  NSUInteger i = 0;
+  while (YES)
+  {
+    char buffer[4];
+    short bufferLength;
+    for (bufferLength = 0; bufferLength < 4; i++)
+    {
+      if (characters[i] == '\0')
+        break;
+      if (isspace(characters[i]) || characters[i] == '=')
+        continue;
+      buffer[bufferLength] = decodingTable[(short)characters[i]];
+      if (buffer[bufferLength++] == CHAR_MAX)      //  Illegal character!
+      {
+        free(bytes);
+        return nil;
+      }
+    }
+
+    if (bufferLength == 0)
+      break;
+    if (bufferLength == 1)      //  At least two characters are needed to produce one byte!
+    {
+      free(bytes);
+      return nil;
+    }
+
+        //  Decode the characters in the buffer to bytes.
+    bytes[length++] = (buffer[0] << 2) | (buffer[1] >> 4);
+    if (bufferLength > 2)
+      bytes[length++] = (buffer[1] << 4) | (buffer[2] >> 2);
+    if (bufferLength > 3)
+      bytes[length++] = (buffer[2] << 6) | buffer[3];
+  }
+
+  realloc(bytes, length);
+  return [NSData dataWithBytesNoCopy:bytes length:length];
+}
+
+- (NSString *)base64Encoding;
+{
+  if ([self length] == 0)
+    return @"";
+
+  char *characters = malloc((([self length] + 2) / 3) * 4);
+  if (characters == NULL)
+    return nil;
+  NSUInteger length = 0;
+
+  NSUInteger i = 0;
+  while (i < [self length])
+  {
+    char buffer[3] = {0,0,0};
+    short bufferLength = 0;
+    while (bufferLength < 3 && i < [self length])
+      buffer[bufferLength++] = ((char *)[self bytes])[i++];
+
+    //  Encode the bytes in the buffer to four characters, including padding "=" characters if necessary.
+    characters[length++] = encodingTable[(buffer[0] & 0xFC) >> 2];
+    characters[length++] = encodingTable[((buffer[0] & 0x03) << 4) | ((buffer[1] & 0xF0) >> 4)];
+    if (bufferLength > 1)
+      characters[length++] = encodingTable[((buffer[1] & 0x0F) << 2) | ((buffer[2] & 0xC0) >> 6)];
+    else characters[length++] = '=';
+    if (bufferLength > 2)
+      characters[length++] = encodingTable[buffer[2] & 0x3F];
+    else characters[length++] = '=';
+  }
+
+  return [[[NSString alloc] initWithBytesNoCopy:characters length:length encoding:NSASCIIStringEncoding freeWhenDone:YES] autorelease];
+}
 @end

--- a/src/Three20Network/Sources/TTRequestLoader.m
+++ b/src/Three20Network/Sources/TTRequestLoader.m
@@ -27,6 +27,7 @@
 #import "Three20Network/private/TTURLRequestQueueInternal.h"
 
 // Core
+#import "Three20Core/NSDataAdditions.h"
 #import "Three20Core/NSObjectAdditions.h"
 #import "Three20Core/TTDebug.h"
 #import "Three20Core/TTDebugFlags.h"
@@ -81,10 +82,33 @@ static const NSInteger kLoadMaxRetries = 2;
 #pragma mark -
 #pragma mark Private
 
+//////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)deliverDataResponse:(NSURL*)URL {
+  // http://tools.ietf.org/html/rfc2397
+  NSArray * dataSplit = [[URL resourceSpecifier] componentsSeparatedByString:@","];
+  if([dataSplit count]!=2) {
+    TTDCONDITIONLOG(TTDFLAG_URLREQUEST, @"UNRECOGNIZED data: URL %@", self.urlPath);
+    return;
+  }
+  if([[dataSplit objectAtIndex:0] rangeOfString:@"base64"].location != NSNotFound) {
+    _responseData   = [[NSData dataWithBase64EncodedString:[dataSplit objectAtIndex:1]] retain];
+  } else {
+      //! To be really conformant need to interpret %xx hex encoded entities.  Skip for now.
+    _responseData   = [[[dataSplit objectAtIndex:1] dataUsingEncoding:NSASCIIStringEncoding] retain];
+  }
+
+  [_queue performSelector:@selector(loader:didLoadResponse:data:) withObject:self
+    withObject:_response withObject:_responseData];
+}
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)connectToURL:(NSURL*)URL {
   TTDCONDITIONLOG(TTDFLAG_URLREQUEST, @"Connecting to %@", _urlPath);
+  // If this is a data: url, we can decode right here ... after a delay to get out of calling thread
+  if([[URL scheme] isEqualToString:@"data"]) {
+    [self performSelector:@selector(deliverDataResponse:) withObject:URL afterDelay:0.1];
+    return;
+  }
   TTNetworkRequestStarted();
 
   TTURLRequest* request = _requests.count == 1 ? [_requests objectAtIndex:0] : nil;


### PR DESCRIPTION
This patch allows use of data:// URIs.

These are useful in the instance where you have a picture taken locally that's not yet sent upstream to a "real" URL.  Encode the thing in a data:// URI and (with this patch) TTImages Just Work.
