### PR TITLE
Missing category UIView+TTUICommon for removing -all_load

### DIFF
--- a/src/Three20UICommon/Sources/UIView+TTUICommon.m
+++ b/src/Three20UICommon/Sources/UIView+TTUICommon.m
@@ -37,3 +37,5 @@
 
 @end
 
+#import "Three20Core/TTCorePreprocessorMacros.h"
+TT_FIX_CATEGORY_BUG(UIView_TTUICommon)


### PR DESCRIPTION
Testing three20 without -all_load I had a crash about missing `[UIView viewController]` selector. I guess there is a missing fix to the `UIView+TTUICommon` category.
This pull request is related to echamberlain force_load patch ([pull request 406](https://github.com/facebook/three20/pull/406)) that was merged recently in development branch: ce15efe0f521ba53f8ad24bc52403ad8ce7b2598
