### PR TITLE
Remove Xcode 3.2.5 targets

### DIFF
--- a/samples/Core/TTCoreDemo/TTCoreDemo.xcodeproj/project.pbxproj
+++ b/samples/Core/TTCoreDemo/TTCoreDemo.xcodeproj/project.pbxproj
@@ -10,18 +10,7 @@
 		1D3623260D0F684500981E51 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D3623250D0F684500981E51 /* AppDelegate.m */; };
 		1D60589B0D05DD56006BFB54 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; };
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
-		667F83E01262FE21008ADC61 /* libThree20Core-Xcode3.2.5.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 66C2E1101262F7BF006DF55A /* libThree20Core-Xcode3.2.5.a */; };
 		668DCFEB1262FA51004C9828 /* Default@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 668DCFEA1262FA51004C9828 /* Default@2x.png */; };
-		66A05B111262FB5B00CE83EF /* Default.png in Resources */ = {isa = PBXBuildFile; fileRef = 6E94C678116D97FF0012B12C /* Default.png */; };
-		66A05B121262FB5B00CE83EF /* Icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 6E94C679116D97FF0012B12C /* Icon.png */; };
-		66A05B131262FB5B00CE83EF /* Three20.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 6E64601A1187B3CD00F08CB1 /* Three20.bundle */; };
-		66A05B141262FB5B00CE83EF /* Default@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 668DCFEA1262FA51004C9828 /* Default@2x.png */; };
-		66A05B161262FB5B00CE83EF /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; };
-		66A05B171262FB5B00CE83EF /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D3623250D0F684500981E51 /* AppDelegate.m */; };
-		66A05B181262FB5B00CE83EF /* PlaygroundViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6EEFBBAA1162829A009B479E /* PlaygroundViewController.m */; };
-		66A05B1A1262FB5B00CE83EF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
-		66A05B1B1262FB5B00CE83EF /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6EEFB94311627E29009B479E /* UIKit.framework */; };
-		66A05B1C1262FB5B00CE83EF /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6EEFBAEB11627F2E009B479E /* CoreGraphics.framework */; };
 		6E645D6E1187999F00F08CB1 /* libThree20Core.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E645D6B1187999700F08CB1 /* libThree20Core.a */; };
 		6E64601B1187B3CD00F08CB1 /* Three20.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 6E64601A1187B3CD00F08CB1 /* Three20.bundle */; };
 		6E94C67A116D97FF0012B12C /* Default.png in Resources */ = {isa = PBXBuildFile; fileRef = 6E94C678116D97FF0012B12C /* Default.png */; };
@@ -32,27 +21,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		66785E741262FD340076FFD2 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E645D621187999700F08CB1 /* Three20Core.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 6650CA791262F6E2003FF804;
-			remoteInfo = "Three20Core-Xcode3.2.5";
-		};
-		66C2E10F1262F7BF006DF55A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E645D621187999700F08CB1 /* Three20Core.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 6650CAA21262F6E2003FF804;
-			remoteInfo = "Three20Core-Xcode3.2.5";
-		};
-		66CFC0F71262F50D00E57607 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E645D621187999700F08CB1 /* Three20Core.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 664961641262EE5000C2C80E;
-			remoteInfo = "UnitTests-Xcode3.2.5";
-		};
 		6E645D6A1187999700F08CB1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 6E645D621187999700F08CB1 /* Three20Core.xcodeproj */;
@@ -83,7 +51,6 @@
 		1D6058910D05DD3D006BFB54 /* TTCoreDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TTCoreDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		668DCFEA1262FA51004C9828 /* Default@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Default@2x.png"; path = "../../Resources/Default@2x.png"; sourceTree = SOURCE_ROOT; };
-		66A05B211262FB5B00CE83EF /* TTCoreDemo-Xcode3.2.5.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "TTCoreDemo-Xcode3.2.5.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6E645D621187999700F08CB1 /* Three20Core.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Three20Core.xcodeproj; path = ../../../src/Three20Core/Three20Core.xcodeproj; sourceTree = SOURCE_ROOT; };
 		6E645DCD11879B0400F08CB1 /* Project.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Project.xcconfig; path = ../Configurations/Project.xcconfig; sourceTree = "<group>"; };
 		6E645DCE11879B0400F08CB1 /* UnitTests.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = UnitTests.xcconfig; path = ../Configurations/UnitTests.xcconfig; sourceTree = "<group>"; };
@@ -113,17 +80,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		66A05B191262FB5B00CE83EF /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				66A05B1A1262FB5B00CE83EF /* Foundation.framework in Frameworks */,
-				66A05B1B1262FB5B00CE83EF /* UIKit.framework in Frameworks */,
-				66A05B1C1262FB5B00CE83EF /* CoreGraphics.framework in Frameworks */,
-				667F83E01262FE21008ADC61 /* libThree20Core-Xcode3.2.5.a in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -141,7 +97,6 @@
 			isa = PBXGroup;
 			children = (
 				1D6058910D05DD3D006BFB54 /* TTCoreDemo.app */,
-				66A05B211262FB5B00CE83EF /* TTCoreDemo-Xcode3.2.5.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -196,9 +151,7 @@
 			isa = PBXGroup;
 			children = (
 				6E645D6B1187999700F08CB1 /* libThree20Core.a */,
-				66C2E1101262F7BF006DF55A /* libThree20Core-Xcode3.2.5.a */,
 				6E645D6D1187999700F08CB1 /* CoreUnitTests.octest */,
-				66CFC0F81262F50D00E57607 /* CoreUnitTests-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -253,24 +206,6 @@
 			productReference = 1D6058910D05DD3D006BFB54 /* TTCoreDemo.app */;
 			productType = "com.apple.product-type.application";
 		};
-		66A05B0D1262FB5B00CE83EF /* TTCoreDemo-Xcode3.2.5 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 66A05B1E1262FB5B00CE83EF /* Build configuration list for PBXNativeTarget "TTCoreDemo-Xcode3.2.5" */;
-			buildPhases = (
-				66A05B101262FB5B00CE83EF /* Resources */,
-				66A05B151262FB5B00CE83EF /* Sources */,
-				66A05B191262FB5B00CE83EF /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				66785E751262FD340076FFD2 /* PBXTargetDependency */,
-			);
-			name = "TTCoreDemo-Xcode3.2.5";
-			productName = TTCoreDemo;
-			productReference = 66A05B211262FB5B00CE83EF /* TTCoreDemo-Xcode3.2.5.app */;
-			productType = "com.apple.product-type.application";
-		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -300,26 +235,11 @@
 			projectRoot = "";
 			targets = (
 				1D6058900D05DD3D006BFB54 /* TTCoreDemo */,
-				66A05B0D1262FB5B00CE83EF /* TTCoreDemo-Xcode3.2.5 */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		66C2E1101262F7BF006DF55A /* libThree20Core-Xcode3.2.5.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libThree20Core-Xcode3.2.5.a";
-			remoteRef = 66C2E10F1262F7BF006DF55A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		66CFC0F81262F50D00E57607 /* CoreUnitTests-Xcode3.2.5.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "CoreUnitTests-Xcode3.2.5.octest";
-			remoteRef = 66CFC0F71262F50D00E57607 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
 		6E645D6B1187999700F08CB1 /* libThree20Core.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
@@ -348,17 +268,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		66A05B101262FB5B00CE83EF /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				66A05B111262FB5B00CE83EF /* Default.png in Resources */,
-				66A05B121262FB5B00CE83EF /* Icon.png in Resources */,
-				66A05B131262FB5B00CE83EF /* Three20.bundle in Resources */,
-				66A05B141262FB5B00CE83EF /* Default@2x.png in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -372,24 +281,9 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		66A05B151262FB5B00CE83EF /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				66A05B161262FB5B00CE83EF /* main.m in Sources */,
-				66A05B171262FB5B00CE83EF /* AppDelegate.m in Sources */,
-				66A05B181262FB5B00CE83EF /* PlaygroundViewController.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		66785E751262FD340076FFD2 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Three20Core-Xcode3.2.5";
-			targetProxy = 66785E741262FD340076FFD2 /* PBXContainerItemProxy */;
-		};
 		6E645D70118799A600F08CB1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Three20Core;
@@ -415,31 +309,6 @@
 			baseConfigurationReference = 6E645DDE11879B3500F08CB1 /* App.xcconfig */;
 			buildSettings = {
 				COPY_PHASE_STRIP = YES;
-				SDKROOT = iphoneos;
-			};
-			name = Release;
-		};
-		66A05B1F1262FB5B00CE83EF /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6E645DDE11879B3500F08CB1 /* App.xcconfig */;
-			buildSettings = {
-				COPY_PHASE_STRIP = NO;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
-				OTHER_LDFLAGS = "$(THREE20CORE325_LIB)";
-				PRODUCT_NAME = "$(BASE_PRODUCT_NAME)-Xcode3.2.5";
-				SDKROOT = iphoneos;
-			};
-			name = Debug;
-		};
-		66A05B201262FB5B00CE83EF /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6E645DDE11879B3500F08CB1 /* App.xcconfig */;
-			buildSettings = {
-				COPY_PHASE_STRIP = YES;
-				OTHER_LDFLAGS = "$(THREE20CORE325_LIB)";
-				PRODUCT_NAME = "$(BASE_PRODUCT_NAME)-Xcode3.2.5";
 				SDKROOT = iphoneos;
 			};
 			name = Release;
@@ -478,15 +347,6 @@
 			buildConfigurations = (
 				1D6058940D05DD3E006BFB54 /* Debug */,
 				1D6058950D05DD3E006BFB54 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		66A05B1E1262FB5B00CE83EF /* Build configuration list for PBXNativeTarget "TTCoreDemo-Xcode3.2.5" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				66A05B1F1262FB5B00CE83EF /* Debug */,
-				66A05B201262FB5B00CE83EF /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/samples/Network/TTNetworkDemo/TTNetworkDemo.xcodeproj/project.pbxproj
+++ b/samples/Network/TTNetworkDemo/TTNetworkDemo.xcodeproj/project.pbxproj
@@ -11,18 +11,6 @@
 		1D60589B0D05DD56006BFB54 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; };
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
 		663DAE791266189B00CF8CEA /* Default@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 663DAE781266189B00CF8CEA /* Default@2x.png */; };
-		66C34A97126618CF00489E9A /* Default.png in Resources */ = {isa = PBXBuildFile; fileRef = 6E94C678116D97FF0012B12C /* Default.png */; };
-		66C34A98126618CF00489E9A /* Icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 6E94C679116D97FF0012B12C /* Icon.png */; };
-		66C34A99126618CF00489E9A /* Three20.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 6E645FEF1187B3C300F08CB1 /* Three20.bundle */; };
-		66C34A9A126618CF00489E9A /* Default@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 663DAE781266189B00CF8CEA /* Default@2x.png */; };
-		66C34A9C126618CF00489E9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; };
-		66C34A9D126618CF00489E9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D3623250D0F684500981E51 /* AppDelegate.m */; };
-		66C34A9E126618CF00489E9A /* PlaygroundViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6EEFBBAA1162829A009B479E /* PlaygroundViewController.m */; };
-		66C34AA0126618CF00489E9A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
-		66C34AA1126618CF00489E9A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6EEFB94311627E29009B479E /* UIKit.framework */; };
-		66C34AA2126618CF00489E9A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6EEFBAEB11627F2E009B479E /* CoreGraphics.framework */; };
-		66C34AB91266190500489E9A /* libThree20Core-Xcode3.2.5.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 66846B841263083A001D2CF9 /* libThree20Core-Xcode3.2.5.a */; };
-		66C34ABA1266190500489E9A /* libThree20Network-Xcode3.2.5.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 66846B911263083A001D2CF9 /* libThree20Network-Xcode3.2.5.a */; };
 		6E645FE71187B39900F08CB1 /* libThree20Network.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E645FDF1187B38B00F08CB1 /* libThree20Network.a */; };
 		6E645FF01187B3C300F08CB1 /* Three20.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 6E645FEF1187B3C300F08CB1 /* Three20.bundle */; };
 		6E6460551187B46A00F08CB1 /* libThree20Core.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E645FD21187B38400F08CB1 /* libThree20Core.a */; };
@@ -34,48 +22,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		66846B831263083A001D2CF9 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E645FCC1187B38400F08CB1 /* Three20Core.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 6650CAA21262F6E2003FF804;
-			remoteInfo = "Three20Core-Xcode3.2.5";
-		};
-		66846B871263083A001D2CF9 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E645FCC1187B38400F08CB1 /* Three20Core.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 664961641262EE5000C2C80E;
-			remoteInfo = "UnitTests-Xcode3.2.5";
-		};
-		66846B901263083A001D2CF9 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E645FD51187B38B00F08CB1 /* Three20Network.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 662D81EF12630516005851C2;
-			remoteInfo = "Three20Network-Xcode3.2.5";
-		};
-		66846B941263083A001D2CF9 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E645FD51187B38B00F08CB1 /* Three20Network.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 662D81B2126304EB005851C2;
-			remoteInfo = "UnitTests-Xcode3.2.5";
-		};
-		66C34AB5126618F600489E9A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E645FCC1187B38400F08CB1 /* Three20Core.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 6650CA791262F6E2003FF804;
-			remoteInfo = "Three20Core-Xcode3.2.5";
-		};
-		66C34AB7126618F600489E9A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E645FD51187B38B00F08CB1 /* Three20Network.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 662D81C912630516005851C2;
-			remoteInfo = "Three20Network-Xcode3.2.5";
-		};
 		6E645FD11187B38400F08CB1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 6E645FCC1187B38400F08CB1 /* Three20Core.xcodeproj */;
@@ -127,7 +73,6 @@
 		1D6058910D05DD3D006BFB54 /* TTNetworkDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TTNetworkDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		663DAE781266189B00CF8CEA /* Default@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Default@2x.png"; path = "../../Resources/Default@2x.png"; sourceTree = SOURCE_ROOT; };
-		66C34AA8126618CF00489E9A /* TTNetworkDemo-Xcode3.2.5.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "TTNetworkDemo-Xcode3.2.5.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6E645FA61187B2E400F08CB1 /* TTNetworkDemo_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TTNetworkDemo_Prefix.pch; path = Headers/TTNetworkDemo_Prefix.pch; sourceTree = "<group>"; };
 		6E645FC01187B30100F08CB1 /* App.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = App.xcconfig; path = Configurations/App.xcconfig; sourceTree = "<group>"; };
 		6E645FC11187B30100F08CB1 /* Project.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Project.xcconfig; path = Configurations/Project.xcconfig; sourceTree = "<group>"; };
@@ -158,18 +103,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		66C34A9F126618CF00489E9A /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				66C34AA0126618CF00489E9A /* Foundation.framework in Frameworks */,
-				66C34AA1126618CF00489E9A /* UIKit.framework in Frameworks */,
-				66C34AA2126618CF00489E9A /* CoreGraphics.framework in Frameworks */,
-				66C34AB91266190500489E9A /* libThree20Core-Xcode3.2.5.a in Frameworks */,
-				66C34ABA1266190500489E9A /* libThree20Network-Xcode3.2.5.a in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -187,7 +120,6 @@
 			isa = PBXGroup;
 			children = (
 				1D6058910D05DD3D006BFB54 /* TTNetworkDemo.app */,
-				66C34AA8126618CF00489E9A /* TTNetworkDemo-Xcode3.2.5.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -261,9 +193,7 @@
 			isa = PBXGroup;
 			children = (
 				6E645FD21187B38400F08CB1 /* libThree20Core.a */,
-				66846B841263083A001D2CF9 /* libThree20Core-Xcode3.2.5.a */,
 				6E645FD41187B38400F08CB1 /* CoreUnitTests.octest */,
-				66846B881263083A001D2CF9 /* CoreUnitTests-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -272,9 +202,7 @@
 			isa = PBXGroup;
 			children = (
 				6E645FDF1187B38B00F08CB1 /* libThree20Network.a */,
-				66846B911263083A001D2CF9 /* libThree20Network-Xcode3.2.5.a */,
 				6E645FE11187B38B00F08CB1 /* NetworkUnitTests.octest */,
-				66846B951263083A001D2CF9 /* NetworkUnitTests-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -310,25 +238,6 @@
 			productReference = 1D6058910D05DD3D006BFB54 /* TTNetworkDemo.app */;
 			productType = "com.apple.product-type.application";
 		};
-		66C34A91126618CF00489E9A /* TTNetworkDemo-Xcode3.2.5 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 66C34AA5126618CF00489E9A /* Build configuration list for PBXNativeTarget "TTNetworkDemo-Xcode3.2.5" */;
-			buildPhases = (
-				66C34A96126618CF00489E9A /* Resources */,
-				66C34A9B126618CF00489E9A /* Sources */,
-				66C34A9F126618CF00489E9A /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				66C34AB6126618F600489E9A /* PBXTargetDependency */,
-				66C34AB8126618F600489E9A /* PBXTargetDependency */,
-			);
-			name = "TTNetworkDemo-Xcode3.2.5";
-			productName = TTCoreDemo;
-			productReference = 66C34AA8126618CF00489E9A /* TTNetworkDemo-Xcode3.2.5.app */;
-			productType = "com.apple.product-type.application";
-		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -362,40 +271,11 @@
 			projectRoot = "";
 			targets = (
 				1D6058900D05DD3D006BFB54 /* TTNetworkDemo */,
-				66C34A91126618CF00489E9A /* TTNetworkDemo-Xcode3.2.5 */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		66846B841263083A001D2CF9 /* libThree20Core-Xcode3.2.5.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libThree20Core-Xcode3.2.5.a";
-			remoteRef = 66846B831263083A001D2CF9 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		66846B881263083A001D2CF9 /* CoreUnitTests-Xcode3.2.5.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "CoreUnitTests-Xcode3.2.5.octest";
-			remoteRef = 66846B871263083A001D2CF9 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		66846B911263083A001D2CF9 /* libThree20Network-Xcode3.2.5.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libThree20Network-Xcode3.2.5.a";
-			remoteRef = 66846B901263083A001D2CF9 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		66846B951263083A001D2CF9 /* NetworkUnitTests-Xcode3.2.5.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "NetworkUnitTests-Xcode3.2.5.octest";
-			remoteRef = 66846B941263083A001D2CF9 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
 		6E645FD21187B38400F08CB1 /* libThree20Core.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
@@ -438,17 +318,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		66C34A96126618CF00489E9A /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				66C34A97126618CF00489E9A /* Default.png in Resources */,
-				66C34A98126618CF00489E9A /* Icon.png in Resources */,
-				66C34A99126618CF00489E9A /* Three20.bundle in Resources */,
-				66C34A9A126618CF00489E9A /* Default@2x.png in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -462,29 +331,9 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		66C34A9B126618CF00489E9A /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				66C34A9C126618CF00489E9A /* main.m in Sources */,
-				66C34A9D126618CF00489E9A /* AppDelegate.m in Sources */,
-				66C34A9E126618CF00489E9A /* PlaygroundViewController.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		66C34AB6126618F600489E9A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Three20Core-Xcode3.2.5";
-			targetProxy = 66C34AB5126618F600489E9A /* PBXContainerItemProxy */;
-		};
-		66C34AB8126618F600489E9A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Three20Network-Xcode3.2.5";
-			targetProxy = 66C34AB7126618F600489E9A /* PBXContainerItemProxy */;
-		};
 		6E6460231187B3F700F08CB1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Three20Network;
@@ -515,37 +364,6 @@
 			baseConfigurationReference = 6E645FC01187B30100F08CB1 /* App.xcconfig */;
 			buildSettings = {
 				COPY_PHASE_STRIP = YES;
-				SDKROOT = iphoneos;
-			};
-			name = Release;
-		};
-		66C34AA6126618CF00489E9A /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6E645FC01187B30100F08CB1 /* App.xcconfig */;
-			buildSettings = {
-				COPY_PHASE_STRIP = NO;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
-				OTHER_LDFLAGS = (
-					"$(THREE20CORE325_LIB)",
-					"$(THREE20NETWORK325_LIB)",
-				);
-				PRODUCT_NAME = "$(BASE_PRODUCT_NAME)-Xcode3.2.5";
-				SDKROOT = iphoneos;
-			};
-			name = Debug;
-		};
-		66C34AA7126618CF00489E9A /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6E645FC01187B30100F08CB1 /* App.xcconfig */;
-			buildSettings = {
-				COPY_PHASE_STRIP = YES;
-				OTHER_LDFLAGS = (
-					"$(THREE20CORE325_LIB)",
-					"$(THREE20NETWORK325_LIB)",
-				);
-				PRODUCT_NAME = "$(BASE_PRODUCT_NAME)-Xcode3.2.5";
 				SDKROOT = iphoneos;
 			};
 			name = Release;
@@ -584,15 +402,6 @@
 			buildConfigurations = (
 				1D6058940D05DD3E006BFB54 /* Debug */,
 				1D6058950D05DD3E006BFB54 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		66C34AA5126618CF00489E9A /* Build configuration list for PBXNativeTarget "TTNetworkDemo-Xcode3.2.5" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				66C34AA6126618CF00489E9A /* Debug */,
-				66C34AA7126618CF00489E9A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/samples/Style/TTCSSStyleSheets/TTCSSStyleSheets.xcodeproj/project.pbxproj
+++ b/samples/Style/TTCSSStyleSheets/TTCSSStyleSheets.xcodeproj/project.pbxproj
@@ -13,28 +13,6 @@
 		1DF5F4E00D08C38300B7A737 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DF5F4DF0D08C38300B7A737 /* UIKit.framework */; };
 		288765FD0DF74451002DB57D /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288765FC0DF74451002DB57D /* CoreGraphics.framework */; };
 		663DB50E1266288E00CF8CEA /* Default@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 663DB50D1266288E00CF8CEA /* Default@2x.png */; };
-		66C34D8212662A2C00489E9A /* Three20.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 6E850F4E11B1761D0071A4FD /* Three20.bundle */; };
-		66C34D8312662A2C00489E9A /* extThree20CSSStyle.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 6E0835B311B4C42100B99C32 /* extThree20CSSStyle.bundle */; };
-		66C34D8412662A2C00489E9A /* Default.png in Resources */ = {isa = PBXBuildFile; fileRef = 6E850FAC11B176F10071A4FD /* Default.png */; };
-		66C34D8512662A2C00489E9A /* Icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 6E850FAD11B176F10071A4FD /* Icon.png */; };
-		66C34D8612662A2C00489E9A /* stylesheet.css in Resources */ = {isa = PBXBuildFile; fileRef = 6E036BF411B38EDC0025E8EE /* stylesheet.css */; };
-		66C34D8712662A2C00489E9A /* Default@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 663DB50D1266288E00CF8CEA /* Default@2x.png */; };
-		66C34D8912662A2C00489E9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; };
-		66C34D8A12662A2C00489E9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D3623250D0F684500981E51 /* AppDelegate.m */; };
-		66C34D8B12662A2C00489E9A /* Atlas.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E850FB711B1795F0071A4FD /* Atlas.m */; };
-		66C34D8C12662A2C00489E9A /* StyleSheetViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E036BF711B38F3C0025E8EE /* StyleSheetViewController.m */; };
-		66C34D8E12662A2C00489E9A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
-		66C34D8F12662A2C00489E9A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DF5F4DF0D08C38300B7A737 /* UIKit.framework */; };
-		66C34D9012662A2C00489E9A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288765FC0DF74451002DB57D /* CoreGraphics.framework */; };
-		66C34D9112662A2C00489E9A /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EB383B6410BBF62B0000B2D2 /* QuartzCore.framework */; };
-		66C34DD912662A8000489E9A /* libThree20Core-Xcode3.2.5.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 663DAEC0126619D000CF8CEA /* libThree20Core-Xcode3.2.5.a */; };
-		66C34DDA12662A8000489E9A /* libThree20Network-Xcode3.2.5.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 663DAECD126619D000CF8CEA /* libThree20Network-Xcode3.2.5.a */; };
-		66C34DDB12662A8000489E9A /* libThree20Style-Xcode3.2.5.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 663DAEDA126619D000CF8CEA /* libThree20Style-Xcode3.2.5.a */; };
-		66C34DDC12662A8000489E9A /* libThree20UICommon-Xcode3.2.5.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 663DAEE7126619D000CF8CEA /* libThree20UICommon-Xcode3.2.5.a */; };
-		66C34DDD12662A8000489E9A /* libThree20UINavigator-Xcode3.2.5.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 663DAEF4126619D000CF8CEA /* libThree20UINavigator-Xcode3.2.5.a */; };
-		66C34DDE12662A8000489E9A /* libThree20UI-Xcode3.2.5.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 663DAF01126619D000CF8CEA /* libThree20UI-Xcode3.2.5.a */; };
-		66C34DDF12662A8000489E9A /* libThree20-Xcode3.2.5.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 663DAF0E126619D000CF8CEA /* libThree20-Xcode3.2.5.a */; };
-		66C34DE012662A8000489E9A /* libextThree20CSSStyle-Xcode3.2.5.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 663DB2CF1266278800CF8CEA /* libextThree20CSSStyle-Xcode3.2.5.a */; };
 		6E036BD011B38E550025E8EE /* libextThree20CSSStyle.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E036BCD11B38E520025E8EE /* libextThree20CSSStyle.a */; };
 		6E036BF511B38EDC0025E8EE /* stylesheet.css in Resources */ = {isa = PBXBuildFile; fileRef = 6E036BF411B38EDC0025E8EE /* stylesheet.css */; };
 		6E036BF811B38F3C0025E8EE /* StyleSheetViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E036BF711B38F3C0025E8EE /* StyleSheetViewController.m */; };
@@ -54,174 +32,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		663DAEBF126619D000CF8CEA /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E3793D411B9B59D0011C497 /* Three20Core.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 6650CAA21262F6E2003FF804;
-			remoteInfo = "Three20Core-Xcode3.2.5";
-		};
-		663DAEC3126619D000CF8CEA /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E3793D411B9B59D0011C497 /* Three20Core.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 664961641262EE5000C2C80E;
-			remoteInfo = "Three20CoreUnitTests-Xcode3.2.5";
-		};
-		663DAECC126619D000CF8CEA /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E3793D711B9B59D0011C497 /* Three20Network.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 662D81EF12630516005851C2;
-			remoteInfo = "Three20Network-Xcode3.2.5";
-		};
-		663DAED0126619D000CF8CEA /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E3793D711B9B59D0011C497 /* Three20Network.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 662D81B2126304EB005851C2;
-			remoteInfo = "Three20NetworkUnitTests-Xcode3.2.5";
-		};
-		663DAED9126619D000CF8CEA /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E3793DA11B9B59D0011C497 /* Three20Style.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 66C16BE912639E2700A7825A;
-			remoteInfo = "Three20Style-Xcode3.2.5";
-		};
-		663DAEDD126619D000CF8CEA /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E3793DA11B9B59D0011C497 /* Three20Style.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 66C16C0112639E4500A7825A;
-			remoteInfo = "Three20StyleUnitTests-Xcode3.2.5";
-		};
-		663DAEE6126619D000CF8CEA /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E3793DD11B9B59D0011C497 /* Three20UICommon.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 665A53761264D54B0032D0BE;
-			remoteInfo = "Three20UICommon-Xcode3.2.5";
-		};
-		663DAEEA126619D000CF8CEA /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E3793DD11B9B59D0011C497 /* Three20UICommon.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 665A53891264D54B0032D0BE;
-			remoteInfo = "Three20UICommonUnitTests-Xcode3.2.5";
-		};
-		663DAEF3126619D000CF8CEA /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E3793E011B9B59D0011C497 /* Three20UINavigator.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 665A54521264DAF70032D0BE;
-			remoteInfo = "Three20UINavigator-Xcode3.2.5";
-		};
-		663DAEF7126619D000CF8CEA /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E3793E011B9B59D0011C497 /* Three20UINavigator.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 665A54681264DAF70032D0BE;
-			remoteInfo = "Three20UINavigatorUnitTests-Xcode3.2.5";
-		};
-		663DAF00126619D000CF8CEA /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E3793E311B9B59D0011C497 /* Three20UI.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 66FC2BC81264E3A400F56B19;
-			remoteInfo = "Three20UI-Xcode3.2.5";
-		};
-		663DAF04126619D000CF8CEA /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E3793E311B9B59D0011C497 /* Three20UI.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 66FC2BE61264E3A500F56B19;
-			remoteInfo = "Three20UIUnitTests-Xcode3.2.5";
-		};
-		663DAF0D126619D000CF8CEA /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E850F7911B1762B0071A4FD /* Three20.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 665A55DE126521740032D0BE;
-			remoteInfo = "Three20-Xcode3.2.5";
-		};
-		663DAF11126619D000CF8CEA /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E850F7911B1762B0071A4FD /* Three20.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 665A55FB126521740032D0BE;
-			remoteInfo = "Three20UnitTests-Xcode3.2.5";
-		};
-		663DB2CE1266278800CF8CEA /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E036BC711B38E520025E8EE /* extThree20CSSStyle.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 66C34B1D12661C0600489E9A;
-			remoteInfo = "extThree20CSSStyle-Xcode3.2.5";
-		};
-		663DB2D21266278800CF8CEA /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E036BC711B38E520025E8EE /* extThree20CSSStyle.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 66C34B3312661C0600489E9A;
-			remoteInfo = "extThree20CSSStyleUnitTests-Xcode3.2.5";
-		};
-		66C34DC912662A5300489E9A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E036BC711B38E520025E8EE /* extThree20CSSStyle.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 66C34B0412661C0500489E9A;
-			remoteInfo = "extThree20CSSStyle-Xcode3.2.5";
-		};
-		66C34DCB12662A5300489E9A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E3793DD11B9B59D0011C497 /* Three20UICommon.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 665A53601264D54B0032D0BE;
-			remoteInfo = "Three20UICommon-Xcode3.2.5";
-		};
-		66C34DCD12662A5300489E9A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E3793DA11B9B59D0011C497 /* Three20Style.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 66C16B6012639E2700A7825A;
-			remoteInfo = "Three20Style-Xcode3.2.5";
-		};
-		66C34DCF12662A5300489E9A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E3793E311B9B59D0011C497 /* Three20UI.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 66FC2AB51264E3A400F56B19;
-			remoteInfo = "Three20UI-Xcode3.2.5";
-		};
-		66C34DD112662A5300489E9A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E850F7911B1762B0071A4FD /* Three20.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 665A55C6126521740032D0BE;
-			remoteInfo = "Three20-Xcode3.2.5";
-		};
-		66C34DD312662A5300489E9A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E3793D411B9B59D0011C497 /* Three20Core.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 6650CA791262F6E2003FF804;
-			remoteInfo = "Three20Core-Xcode3.2.5";
-		};
-		66C34DD512662A5300489E9A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E3793D711B9B59D0011C497 /* Three20Network.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 662D81C912630516005851C2;
-			remoteInfo = "Three20Network-Xcode3.2.5";
-		};
-		66C34DD712662A5300489E9A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E3793E011B9B59D0011C497 /* Three20UINavigator.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 665A541D1264DAF70032D0BE;
-			remoteInfo = "Three20UINavigator-Xcode3.2.5";
-		};
 		6E036BCC11B38E520025E8EE /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 6E036BC711B38E520025E8EE /* extThree20CSSStyle.xcodeproj */;
@@ -401,7 +211,6 @@
 		288765FC0DF74451002DB57D /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		663DB50D1266288E00CF8CEA /* Default@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Default@2x.png"; path = "../../Resources/Default@2x.png"; sourceTree = SOURCE_ROOT; };
-		66C34D9D12662A2C00489E9A /* TTCSSStyleSheets-Xcode3.2.5.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "TTCSSStyleSheets-Xcode3.2.5.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6E036BC711B38E520025E8EE /* extThree20CSSStyle.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = extThree20CSSStyle.xcodeproj; path = ../../../src/extThree20CSSStyle/extThree20CSSStyle.xcodeproj; sourceTree = SOURCE_ROOT; };
 		6E036BF411B38EDC0025E8EE /* stylesheet.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; name = stylesheet.css; path = Resources/stylesheet.css; sourceTree = "<group>"; };
 		6E036BF611B38F3C0025E8EE /* StyleSheetViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StyleSheetViewController.h; sourceTree = "<group>"; };
@@ -448,25 +257,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		66C34D8D12662A2C00489E9A /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				66C34DD912662A8000489E9A /* libThree20Core-Xcode3.2.5.a in Frameworks */,
-				66C34DDA12662A8000489E9A /* libThree20Network-Xcode3.2.5.a in Frameworks */,
-				66C34DDB12662A8000489E9A /* libThree20Style-Xcode3.2.5.a in Frameworks */,
-				66C34DDC12662A8000489E9A /* libThree20UICommon-Xcode3.2.5.a in Frameworks */,
-				66C34DDD12662A8000489E9A /* libThree20UINavigator-Xcode3.2.5.a in Frameworks */,
-				66C34DDE12662A8000489E9A /* libThree20UI-Xcode3.2.5.a in Frameworks */,
-				66C34DDF12662A8000489E9A /* libThree20-Xcode3.2.5.a in Frameworks */,
-				66C34DE012662A8000489E9A /* libextThree20CSSStyle-Xcode3.2.5.a in Frameworks */,
-				66C34D8E12662A2C00489E9A /* Foundation.framework in Frameworks */,
-				66C34D8F12662A2C00489E9A /* UIKit.framework in Frameworks */,
-				66C34D9012662A2C00489E9A /* CoreGraphics.framework in Frameworks */,
-				66C34D9112662A2C00489E9A /* QuartzCore.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -486,7 +276,6 @@
 			isa = PBXGroup;
 			children = (
 				1D6058910D05DD3D006BFB54 /* TTCSSStyleSheets.app */,
-				66C34D9D12662A2C00489E9A /* TTCSSStyleSheets-Xcode3.2.5.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -543,9 +332,7 @@
 			isa = PBXGroup;
 			children = (
 				6E036BCD11B38E520025E8EE /* libextThree20CSSStyle.a */,
-				663DB2CF1266278800CF8CEA /* libextThree20CSSStyle-Xcode3.2.5.a */,
 				6E036BCF11B38E520025E8EE /* extCSSStyleUnitTests.octest */,
-				663DB2D31266278800CF8CEA /* extCSSStyleUnitTests-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -554,9 +341,7 @@
 			isa = PBXGroup;
 			children = (
 				6E3793E911B9B59D0011C497 /* libThree20Core.a */,
-				663DAEC0126619D000CF8CEA /* libThree20Core-Xcode3.2.5.a */,
 				6E3793EB11B9B59D0011C497 /* CoreUnitTests.octest */,
-				663DAEC4126619D000CF8CEA /* CoreUnitTests-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -565,9 +350,7 @@
 			isa = PBXGroup;
 			children = (
 				6E3793EF11B9B59D0011C497 /* libThree20Network.a */,
-				663DAECD126619D000CF8CEA /* libThree20Network-Xcode3.2.5.a */,
 				6E3793F111B9B59D0011C497 /* NetworkUnitTests.octest */,
-				663DAED1126619D000CF8CEA /* NetworkUnitTests-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -576,9 +359,7 @@
 			isa = PBXGroup;
 			children = (
 				6E3793F511B9B59D0011C497 /* libThree20Style.a */,
-				663DAEDA126619D000CF8CEA /* libThree20Style-Xcode3.2.5.a */,
 				6E3793F711B9B59D0011C497 /* StyleUnitTests.octest */,
-				663DAEDE126619D000CF8CEA /* StyleUnitTests-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -587,9 +368,7 @@
 			isa = PBXGroup;
 			children = (
 				6E3793FB11B9B59D0011C497 /* libThree20UICommon.a */,
-				663DAEE7126619D000CF8CEA /* libThree20UICommon-Xcode3.2.5.a */,
 				6E3793FD11B9B59D0011C497 /* UICommonUnitTests.octest */,
-				663DAEEB126619D000CF8CEA /* UICommonUnitTests-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -598,9 +377,7 @@
 			isa = PBXGroup;
 			children = (
 				6E37940111B9B59D0011C497 /* libThree20UINavigator.a */,
-				663DAEF4126619D000CF8CEA /* libThree20UINavigator-Xcode3.2.5.a */,
 				6E37940311B9B59D0011C497 /* UINavigatorUnitTests.octest */,
-				663DAEF8126619D000CF8CEA /* UINavigatorUnitTests-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -609,9 +386,7 @@
 			isa = PBXGroup;
 			children = (
 				6E37940711B9B59D0011C497 /* libThree20UI.a */,
-				663DAF01126619D000CF8CEA /* libThree20UI-Xcode3.2.5.a */,
 				6E37940911B9B59D0011C497 /* UIUnitTests.octest */,
-				663DAF05126619D000CF8CEA /* UIUnitTests-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -653,9 +428,7 @@
 			isa = PBXGroup;
 			children = (
 				6E850F8811B1762B0071A4FD /* libThree20.a */,
-				663DAF0E126619D000CF8CEA /* libThree20-Xcode3.2.5.a */,
 				6E850F8A11B1762B0071A4FD /* Three20UnitTests.octest */,
-				663DAF12126619D000CF8CEA /* Three20UnitTests-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -704,31 +477,6 @@
 			name = TTCSSStyleSheets;
 			productName = TTStylePreview;
 			productReference = 1D6058910D05DD3D006BFB54 /* TTCSSStyleSheets.app */;
-			productType = "com.apple.product-type.application";
-		};
-		66C34D7012662A2C00489E9A /* TTCSSStyleSheets-Xcode3.2.5 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 66C34D9A12662A2C00489E9A /* Build configuration list for PBXNativeTarget "TTCSSStyleSheets-Xcode3.2.5" */;
-			buildPhases = (
-				66C34D8112662A2C00489E9A /* Resources */,
-				66C34D8812662A2C00489E9A /* Sources */,
-				66C34D8D12662A2C00489E9A /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				66C34DD412662A5300489E9A /* PBXTargetDependency */,
-				66C34DD612662A5300489E9A /* PBXTargetDependency */,
-				66C34DCE12662A5300489E9A /* PBXTargetDependency */,
-				66C34DCC12662A5300489E9A /* PBXTargetDependency */,
-				66C34DD812662A5300489E9A /* PBXTargetDependency */,
-				66C34DD012662A5300489E9A /* PBXTargetDependency */,
-				66C34DD212662A5300489E9A /* PBXTargetDependency */,
-				66C34DCA12662A5300489E9A /* PBXTargetDependency */,
-			);
-			name = "TTCSSStyleSheets-Xcode3.2.5";
-			productName = TTStylePreview;
-			productReference = 66C34D9D12662A2C00489E9A /* TTCSSStyleSheets-Xcode3.2.5.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -788,124 +536,11 @@
 			projectRoot = "";
 			targets = (
 				1D6058900D05DD3D006BFB54 /* TTCSSStyleSheets */,
-				66C34D7012662A2C00489E9A /* TTCSSStyleSheets-Xcode3.2.5 */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		663DAEC0126619D000CF8CEA /* libThree20Core-Xcode3.2.5.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libThree20Core-Xcode3.2.5.a";
-			remoteRef = 663DAEBF126619D000CF8CEA /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		663DAEC4126619D000CF8CEA /* CoreUnitTests-Xcode3.2.5.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "CoreUnitTests-Xcode3.2.5.octest";
-			remoteRef = 663DAEC3126619D000CF8CEA /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		663DAECD126619D000CF8CEA /* libThree20Network-Xcode3.2.5.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libThree20Network-Xcode3.2.5.a";
-			remoteRef = 663DAECC126619D000CF8CEA /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		663DAED1126619D000CF8CEA /* NetworkUnitTests-Xcode3.2.5.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "NetworkUnitTests-Xcode3.2.5.octest";
-			remoteRef = 663DAED0126619D000CF8CEA /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		663DAEDA126619D000CF8CEA /* libThree20Style-Xcode3.2.5.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libThree20Style-Xcode3.2.5.a";
-			remoteRef = 663DAED9126619D000CF8CEA /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		663DAEDE126619D000CF8CEA /* StyleUnitTests-Xcode3.2.5.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "StyleUnitTests-Xcode3.2.5.octest";
-			remoteRef = 663DAEDD126619D000CF8CEA /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		663DAEE7126619D000CF8CEA /* libThree20UICommon-Xcode3.2.5.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libThree20UICommon-Xcode3.2.5.a";
-			remoteRef = 663DAEE6126619D000CF8CEA /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		663DAEEB126619D000CF8CEA /* UICommonUnitTests-Xcode3.2.5.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "UICommonUnitTests-Xcode3.2.5.octest";
-			remoteRef = 663DAEEA126619D000CF8CEA /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		663DAEF4126619D000CF8CEA /* libThree20UINavigator-Xcode3.2.5.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libThree20UINavigator-Xcode3.2.5.a";
-			remoteRef = 663DAEF3126619D000CF8CEA /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		663DAEF8126619D000CF8CEA /* UINavigatorUnitTests-Xcode3.2.5.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "UINavigatorUnitTests-Xcode3.2.5.octest";
-			remoteRef = 663DAEF7126619D000CF8CEA /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		663DAF01126619D000CF8CEA /* libThree20UI-Xcode3.2.5.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libThree20UI-Xcode3.2.5.a";
-			remoteRef = 663DAF00126619D000CF8CEA /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		663DAF05126619D000CF8CEA /* UIUnitTests-Xcode3.2.5.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "UIUnitTests-Xcode3.2.5.octest";
-			remoteRef = 663DAF04126619D000CF8CEA /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		663DAF0E126619D000CF8CEA /* libThree20-Xcode3.2.5.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libThree20-Xcode3.2.5.a";
-			remoteRef = 663DAF0D126619D000CF8CEA /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		663DAF12126619D000CF8CEA /* Three20UnitTests-Xcode3.2.5.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "Three20UnitTests-Xcode3.2.5.octest";
-			remoteRef = 663DAF11126619D000CF8CEA /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		663DB2CF1266278800CF8CEA /* libextThree20CSSStyle-Xcode3.2.5.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libextThree20CSSStyle-Xcode3.2.5.a";
-			remoteRef = 663DB2CE1266278800CF8CEA /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		663DB2D31266278800CF8CEA /* extCSSStyleUnitTests-Xcode3.2.5.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "extCSSStyleUnitTests-Xcode3.2.5.octest";
-			remoteRef = 663DB2D21266278800CF8CEA /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
 		6E036BCD11B38E520025E8EE /* libextThree20CSSStyle.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
@@ -1034,19 +669,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		66C34D8112662A2C00489E9A /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				66C34D8212662A2C00489E9A /* Three20.bundle in Resources */,
-				66C34D8312662A2C00489E9A /* extThree20CSSStyle.bundle in Resources */,
-				66C34D8412662A2C00489E9A /* Default.png in Resources */,
-				66C34D8512662A2C00489E9A /* Icon.png in Resources */,
-				66C34D8612662A2C00489E9A /* stylesheet.css in Resources */,
-				66C34D8712662A2C00489E9A /* Default@2x.png in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -1061,60 +683,9 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		66C34D8812662A2C00489E9A /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				66C34D8912662A2C00489E9A /* main.m in Sources */,
-				66C34D8A12662A2C00489E9A /* AppDelegate.m in Sources */,
-				66C34D8B12662A2C00489E9A /* Atlas.m in Sources */,
-				66C34D8C12662A2C00489E9A /* StyleSheetViewController.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		66C34DCA12662A5300489E9A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "extThree20CSSStyle-Xcode3.2.5";
-			targetProxy = 66C34DC912662A5300489E9A /* PBXContainerItemProxy */;
-		};
-		66C34DCC12662A5300489E9A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Three20UICommon-Xcode3.2.5";
-			targetProxy = 66C34DCB12662A5300489E9A /* PBXContainerItemProxy */;
-		};
-		66C34DCE12662A5300489E9A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Three20Style-Xcode3.2.5";
-			targetProxy = 66C34DCD12662A5300489E9A /* PBXContainerItemProxy */;
-		};
-		66C34DD012662A5300489E9A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Three20UI-Xcode3.2.5";
-			targetProxy = 66C34DCF12662A5300489E9A /* PBXContainerItemProxy */;
-		};
-		66C34DD212662A5300489E9A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Three20-Xcode3.2.5";
-			targetProxy = 66C34DD112662A5300489E9A /* PBXContainerItemProxy */;
-		};
-		66C34DD412662A5300489E9A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Three20Core-Xcode3.2.5";
-			targetProxy = 66C34DD312662A5300489E9A /* PBXContainerItemProxy */;
-		};
-		66C34DD612662A5300489E9A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Three20Network-Xcode3.2.5";
-			targetProxy = 66C34DD512662A5300489E9A /* PBXContainerItemProxy */;
-		};
-		66C34DD812662A5300489E9A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Three20UINavigator-Xcode3.2.5";
-			targetProxy = 66C34DD712662A5300489E9A /* PBXContainerItemProxy */;
-		};
 		6E036BE411B38E5F0025E8EE /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = extThree20CSSStyle;
@@ -1185,53 +756,6 @@
 			};
 			name = Release;
 		};
-		66C34D9B12662A2C00489E9A /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6E850F4811B175FD0071A4FD /* App.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				COPY_PHASE_STRIP = NO;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
-				OTHER_LDFLAGS = (
-					"$(THREE20CORE325_LIB)",
-					"$(THREE20NETWORK325_LIB)",
-					"$(THREE20STYLE325_LIB)",
-					"$(THREE20UICOMMON325_LIB)",
-					"$(THREE20UINAVIGATOR325_LIB)",
-					"$(THREE20UI325_LIB)",
-					"$(THREE20325_LIB)",
-					"$(EXTTHREE20CSSSTYLE325_LIB)",
-				);
-				PRODUCT_NAME = "$(BASE_PRODUCT_NAME)-Xcode3.2.5";
-				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
-				SDKROOT = iphoneos;
-			};
-			name = Debug;
-		};
-		66C34D9C12662A2C00489E9A /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6E850F4811B175FD0071A4FD /* App.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				COPY_PHASE_STRIP = YES;
-				OTHER_LDFLAGS = (
-					"$(THREE20CORE325_LIB)",
-					"$(THREE20NETWORK325_LIB)",
-					"$(THREE20STYLE325_LIB)",
-					"$(THREE20UICOMMON325_LIB)",
-					"$(THREE20UINAVIGATOR325_LIB)",
-					"$(THREE20UI325_LIB)",
-					"$(THREE20325_LIB)",
-					"$(EXTTHREE20CSSSTYLE325_LIB)",
-				);
-				PRODUCT_NAME = "$(BASE_PRODUCT_NAME)-Xcode3.2.5";
-				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
-				SDKROOT = iphoneos;
-			};
-			name = Release;
-		};
 		C01FCF4F08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6E850F4911B175FD0071A4FD /* Project.xcconfig */;
@@ -1266,15 +790,6 @@
 			buildConfigurations = (
 				1D6058940D05DD3E006BFB54 /* Debug */,
 				1D6058950D05DD3E006BFB54 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		66C34D9A12662A2C00489E9A /* Build configuration list for PBXNativeTarget "TTCSSStyleSheets-Xcode3.2.5" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				66C34D9B12662A2C00489E9A /* Debug */,
-				66C34D9C12662A2C00489E9A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/samples/Style/TTStyleCatalog/TTStyleCatalog.xcodeproj/project.pbxproj
+++ b/samples/Style/TTStyleCatalog/TTStyleCatalog.xcodeproj/project.pbxproj
@@ -12,27 +12,6 @@
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
 		1DF5F4E00D08C38300B7A737 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DF5F4DF0D08C38300B7A737 /* UIKit.framework */; };
 		288765FD0DF74451002DB57D /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288765FC0DF74451002DB57D /* CoreGraphics.framework */; };
-		664DFD2A12662D64004C20C2 /* Three20.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 6E850F4E11B1761D0071A4FD /* Three20.bundle */; };
-		664DFD2B12662D64004C20C2 /* Default.png in Resources */ = {isa = PBXBuildFile; fileRef = 6E850FAC11B176F10071A4FD /* Default.png */; };
-		664DFD2C12662D64004C20C2 /* Icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 6E850FAD11B176F10071A4FD /* Icon.png */; };
-		664DFD2D12662D64004C20C2 /* Default@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 665E980C12662D0C0025FA42 /* Default@2x.png */; };
-		664DFD2F12662D64004C20C2 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; };
-		664DFD3012662D64004C20C2 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D3623250D0F684500981E51 /* AppDelegate.m */; };
-		664DFD3112662D64004C20C2 /* MainMenuViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E850FB411B179400071A4FD /* MainMenuViewController.m */; };
-		664DFD3212662D64004C20C2 /* Atlas.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E850FB711B1795F0071A4FD /* Atlas.m */; };
-		664DFD3312662D64004C20C2 /* StyleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E850FD111B17A450071A4FD /* StyleViewController.m */; };
-		664DFD3412662D64004C20C2 /* StyleView.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E850FFB11B17CBE0071A4FD /* StyleView.m */; };
-		664DFD3612662D64004C20C2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
-		664DFD3712662D64004C20C2 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DF5F4DF0D08C38300B7A737 /* UIKit.framework */; };
-		664DFD3812662D64004C20C2 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288765FC0DF74451002DB57D /* CoreGraphics.framework */; };
-		664DFD3912662D64004C20C2 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EB383B6410BBF62B0000B2D2 /* QuartzCore.framework */; };
-		664DFD7812662D93004C20C2 /* libThree20Core-Xcode3.2.5.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 665E978C12662C6A0025FA42 /* libThree20Core-Xcode3.2.5.a */; };
-		664DFD7912662D93004C20C2 /* libThree20Network-Xcode3.2.5.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 665E979912662C6A0025FA42 /* libThree20Network-Xcode3.2.5.a */; };
-		664DFD7A12662D93004C20C2 /* libThree20Style-Xcode3.2.5.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 665E97A612662C6A0025FA42 /* libThree20Style-Xcode3.2.5.a */; };
-		664DFD7B12662D93004C20C2 /* libThree20UICommon-Xcode3.2.5.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 665E97B312662C6A0025FA42 /* libThree20UICommon-Xcode3.2.5.a */; };
-		664DFD7C12662D93004C20C2 /* libThree20UINavigator-Xcode3.2.5.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 665E97C012662C6A0025FA42 /* libThree20UINavigator-Xcode3.2.5.a */; };
-		664DFD7D12662D93004C20C2 /* libThree20UI-Xcode3.2.5.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 665E97CD12662C6A0025FA42 /* libThree20UI-Xcode3.2.5.a */; };
-		664DFD7E12662D93004C20C2 /* libThree20-Xcode3.2.5.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 665E97DA12662C6A0025FA42 /* libThree20-Xcode3.2.5.a */; };
 		665E980D12662D0C0025FA42 /* Default@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 665E980C12662D0C0025FA42 /* Default@2x.png */; };
 		6E37949111B9B63E0011C497 /* libThree20Core.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E37946E11B9B6300011C497 /* libThree20Core.a */; };
 		6E37949211B9B63E0011C497 /* libThree20Network.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E37947411B9B6300011C497 /* libThree20Network.a */; };
@@ -52,153 +31,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		664DFD6A12662D7D004C20C2 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37945C11B9B6300011C497 /* Three20Network.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 662D81C912630516005851C2;
-			remoteInfo = "Three20Network-Xcode3.2.5";
-		};
-		664DFD6C12662D7D004C20C2 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37945911B9B6300011C497 /* Three20Core.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 6650CA791262F6E2003FF804;
-			remoteInfo = "Three20Core-Xcode3.2.5";
-		};
-		664DFD6E12662D7D004C20C2 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37946811B9B6300011C497 /* Three20UI.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 66FC2AB51264E3A400F56B19;
-			remoteInfo = "Three20UI-Xcode3.2.5";
-		};
-		664DFD7012662D7D004C20C2 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37945F11B9B6300011C497 /* Three20Style.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 66C16B6012639E2700A7825A;
-			remoteInfo = "Three20Style-Xcode3.2.5";
-		};
-		664DFD7212662D7D004C20C2 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37946211B9B6300011C497 /* Three20UICommon.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 665A53601264D54B0032D0BE;
-			remoteInfo = "Three20UICommon-Xcode3.2.5";
-		};
-		664DFD7412662D7D004C20C2 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37946511B9B6300011C497 /* Three20UINavigator.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 665A541D1264DAF70032D0BE;
-			remoteInfo = "Three20UINavigator-Xcode3.2.5";
-		};
-		664DFD7612662D7D004C20C2 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E850F7911B1762B0071A4FD /* Three20.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 665A55C6126521740032D0BE;
-			remoteInfo = "Three20-Xcode3.2.5";
-		};
-		665E978B12662C6A0025FA42 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37945911B9B6300011C497 /* Three20Core.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 6650CAA21262F6E2003FF804;
-			remoteInfo = "Three20Core-Xcode3.2.5";
-		};
-		665E978F12662C6A0025FA42 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37945911B9B6300011C497 /* Three20Core.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 664961641262EE5000C2C80E;
-			remoteInfo = "Three20CoreUnitTests-Xcode3.2.5";
-		};
-		665E979812662C6A0025FA42 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37945C11B9B6300011C497 /* Three20Network.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 662D81EF12630516005851C2;
-			remoteInfo = "Three20Network-Xcode3.2.5";
-		};
-		665E979C12662C6A0025FA42 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37945C11B9B6300011C497 /* Three20Network.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 662D81B2126304EB005851C2;
-			remoteInfo = "Three20NetworkUnitTests-Xcode3.2.5";
-		};
-		665E97A512662C6A0025FA42 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37945F11B9B6300011C497 /* Three20Style.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 66C16BE912639E2700A7825A;
-			remoteInfo = "Three20Style-Xcode3.2.5";
-		};
-		665E97A912662C6A0025FA42 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37945F11B9B6300011C497 /* Three20Style.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 66C16C0112639E4500A7825A;
-			remoteInfo = "Three20StyleUnitTests-Xcode3.2.5";
-		};
-		665E97B212662C6A0025FA42 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37946211B9B6300011C497 /* Three20UICommon.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 665A53761264D54B0032D0BE;
-			remoteInfo = "Three20UICommon-Xcode3.2.5";
-		};
-		665E97B612662C6A0025FA42 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37946211B9B6300011C497 /* Three20UICommon.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 665A53891264D54B0032D0BE;
-			remoteInfo = "Three20UICommonUnitTests-Xcode3.2.5";
-		};
-		665E97BF12662C6A0025FA42 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37946511B9B6300011C497 /* Three20UINavigator.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 665A54521264DAF70032D0BE;
-			remoteInfo = "Three20UINavigator-Xcode3.2.5";
-		};
-		665E97C312662C6A0025FA42 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37946511B9B6300011C497 /* Three20UINavigator.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 665A54681264DAF70032D0BE;
-			remoteInfo = "Three20UINavigatorUnitTests-Xcode3.2.5";
-		};
-		665E97CC12662C6A0025FA42 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37946811B9B6300011C497 /* Three20UI.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 66FC2BC81264E3A400F56B19;
-			remoteInfo = "Three20UI-Xcode3.2.5";
-		};
-		665E97D012662C6A0025FA42 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37946811B9B6300011C497 /* Three20UI.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 66FC2BE61264E3A500F56B19;
-			remoteInfo = "Three20UIUnitTests-Xcode3.2.5";
-		};
-		665E97D912662C6A0025FA42 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E850F7911B1762B0071A4FD /* Three20.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 665A55DE126521740032D0BE;
-			remoteInfo = "Three20-Xcode3.2.5";
-		};
-		665E97DD12662C6A0025FA42 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E850F7911B1762B0071A4FD /* Three20.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 665A55FB126521740032D0BE;
-			remoteInfo = "Three20UnitTests-Xcode3.2.5";
-		};
 		6E37946D11B9B6300011C497 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 6E37945911B9B6300011C497 /* Three20Core.xcodeproj */;
@@ -356,7 +188,6 @@
 		1DF5F4DF0D08C38300B7A737 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		288765FC0DF74451002DB57D /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
-		664DFD4412662D64004C20C2 /* TTStyleCatalog-Xcode3.2.5.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "TTStyleCatalog-Xcode3.2.5.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		665E980C12662D0C0025FA42 /* Default@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Default@2x.png"; path = "../../Resources/Default@2x.png"; sourceTree = SOURCE_ROOT; };
 		6E37945911B9B6300011C497 /* Three20Core.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Three20Core.xcodeproj; path = ../../../src/Three20Core/Three20Core.xcodeproj; sourceTree = SOURCE_ROOT; };
 		6E37945C11B9B6300011C497 /* Three20Network.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Three20Network.xcodeproj; path = ../../../src/Three20Network/Three20Network.xcodeproj; sourceTree = SOURCE_ROOT; };
@@ -404,24 +235,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		664DFD3512662D64004C20C2 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				664DFD7812662D93004C20C2 /* libThree20Core-Xcode3.2.5.a in Frameworks */,
-				664DFD7912662D93004C20C2 /* libThree20Network-Xcode3.2.5.a in Frameworks */,
-				664DFD7A12662D93004C20C2 /* libThree20Style-Xcode3.2.5.a in Frameworks */,
-				664DFD7B12662D93004C20C2 /* libThree20UICommon-Xcode3.2.5.a in Frameworks */,
-				664DFD7C12662D93004C20C2 /* libThree20UINavigator-Xcode3.2.5.a in Frameworks */,
-				664DFD7D12662D93004C20C2 /* libThree20UI-Xcode3.2.5.a in Frameworks */,
-				664DFD7E12662D93004C20C2 /* libThree20-Xcode3.2.5.a in Frameworks */,
-				664DFD3612662D64004C20C2 /* Foundation.framework in Frameworks */,
-				664DFD3712662D64004C20C2 /* UIKit.framework in Frameworks */,
-				664DFD3812662D64004C20C2 /* CoreGraphics.framework in Frameworks */,
-				664DFD3912662D64004C20C2 /* QuartzCore.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -441,7 +254,6 @@
 			isa = PBXGroup;
 			children = (
 				1D6058910D05DD3D006BFB54 /* TTStyleCatalog.app */,
-				664DFD4412662D64004C20C2 /* TTStyleCatalog-Xcode3.2.5.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -496,9 +308,7 @@
 			isa = PBXGroup;
 			children = (
 				6E37946E11B9B6300011C497 /* libThree20Core.a */,
-				665E978C12662C6A0025FA42 /* libThree20Core-Xcode3.2.5.a */,
 				6E37947011B9B6300011C497 /* CoreUnitTests.octest */,
-				665E979012662C6A0025FA42 /* CoreUnitTests-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -507,9 +317,7 @@
 			isa = PBXGroup;
 			children = (
 				6E37947411B9B6300011C497 /* libThree20Network.a */,
-				665E979912662C6A0025FA42 /* libThree20Network-Xcode3.2.5.a */,
 				6E37947611B9B6300011C497 /* NetworkUnitTests.octest */,
-				665E979D12662C6A0025FA42 /* NetworkUnitTests-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -518,9 +326,7 @@
 			isa = PBXGroup;
 			children = (
 				6E37947A11B9B6300011C497 /* libThree20Style.a */,
-				665E97A612662C6A0025FA42 /* libThree20Style-Xcode3.2.5.a */,
 				6E37947C11B9B6300011C497 /* StyleUnitTests.octest */,
-				665E97AA12662C6A0025FA42 /* StyleUnitTests-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -529,9 +335,7 @@
 			isa = PBXGroup;
 			children = (
 				6E37948011B9B6300011C497 /* libThree20UICommon.a */,
-				665E97B312662C6A0025FA42 /* libThree20UICommon-Xcode3.2.5.a */,
 				6E37948211B9B6300011C497 /* UICommonUnitTests.octest */,
-				665E97B712662C6A0025FA42 /* UICommonUnitTests-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -540,9 +344,7 @@
 			isa = PBXGroup;
 			children = (
 				6E37948611B9B6300011C497 /* libThree20UINavigator.a */,
-				665E97C012662C6A0025FA42 /* libThree20UINavigator-Xcode3.2.5.a */,
 				6E37948811B9B6300011C497 /* UINavigatorUnitTests.octest */,
-				665E97C412662C6A0025FA42 /* UINavigatorUnitTests-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -551,9 +353,7 @@
 			isa = PBXGroup;
 			children = (
 				6E37948C11B9B6300011C497 /* libThree20UI.a */,
-				665E97CD12662C6A0025FA42 /* libThree20UI-Xcode3.2.5.a */,
 				6E37948E11B9B6300011C497 /* UIUnitTests.octest */,
-				665E97D112662C6A0025FA42 /* UIUnitTests-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -587,9 +387,7 @@
 			isa = PBXGroup;
 			children = (
 				6E850F8811B1762B0071A4FD /* libThree20.a */,
-				665E97DA12662C6A0025FA42 /* libThree20-Xcode3.2.5.a */,
 				6E850F8A11B1762B0071A4FD /* Three20UnitTests.octest */,
-				665E97DE12662C6A0025FA42 /* Three20UnitTests-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -666,30 +464,6 @@
 			productReference = 1D6058910D05DD3D006BFB54 /* TTStyleCatalog.app */;
 			productType = "com.apple.product-type.application";
 		};
-		664DFD1A12662D64004C20C2 /* TTStyleCatalog-Xcode3.2.5 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 664DFD4112662D64004C20C2 /* Build configuration list for PBXNativeTarget "TTStyleCatalog-Xcode3.2.5" */;
-			buildPhases = (
-				664DFD2912662D64004C20C2 /* Resources */,
-				664DFD2E12662D64004C20C2 /* Sources */,
-				664DFD3512662D64004C20C2 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				664DFD6B12662D7D004C20C2 /* PBXTargetDependency */,
-				664DFD6D12662D7D004C20C2 /* PBXTargetDependency */,
-				664DFD6F12662D7D004C20C2 /* PBXTargetDependency */,
-				664DFD7112662D7D004C20C2 /* PBXTargetDependency */,
-				664DFD7312662D7D004C20C2 /* PBXTargetDependency */,
-				664DFD7512662D7D004C20C2 /* PBXTargetDependency */,
-				664DFD7712662D7D004C20C2 /* PBXTargetDependency */,
-			);
-			name = "TTStyleCatalog-Xcode3.2.5";
-			productName = TTStylePreview;
-			productReference = 664DFD4412662D64004C20C2 /* TTStyleCatalog-Xcode3.2.5.app */;
-			productType = "com.apple.product-type.application";
-		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -740,110 +514,11 @@
 			projectRoot = "";
 			targets = (
 				1D6058900D05DD3D006BFB54 /* TTStyleCatalog */,
-				664DFD1A12662D64004C20C2 /* TTStyleCatalog-Xcode3.2.5 */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		665E978C12662C6A0025FA42 /* libThree20Core-Xcode3.2.5.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libThree20Core-Xcode3.2.5.a";
-			remoteRef = 665E978B12662C6A0025FA42 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		665E979012662C6A0025FA42 /* CoreUnitTests-Xcode3.2.5.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "CoreUnitTests-Xcode3.2.5.octest";
-			remoteRef = 665E978F12662C6A0025FA42 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		665E979912662C6A0025FA42 /* libThree20Network-Xcode3.2.5.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libThree20Network-Xcode3.2.5.a";
-			remoteRef = 665E979812662C6A0025FA42 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		665E979D12662C6A0025FA42 /* NetworkUnitTests-Xcode3.2.5.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "NetworkUnitTests-Xcode3.2.5.octest";
-			remoteRef = 665E979C12662C6A0025FA42 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		665E97A612662C6A0025FA42 /* libThree20Style-Xcode3.2.5.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libThree20Style-Xcode3.2.5.a";
-			remoteRef = 665E97A512662C6A0025FA42 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		665E97AA12662C6A0025FA42 /* StyleUnitTests-Xcode3.2.5.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "StyleUnitTests-Xcode3.2.5.octest";
-			remoteRef = 665E97A912662C6A0025FA42 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		665E97B312662C6A0025FA42 /* libThree20UICommon-Xcode3.2.5.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libThree20UICommon-Xcode3.2.5.a";
-			remoteRef = 665E97B212662C6A0025FA42 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		665E97B712662C6A0025FA42 /* UICommonUnitTests-Xcode3.2.5.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "UICommonUnitTests-Xcode3.2.5.octest";
-			remoteRef = 665E97B612662C6A0025FA42 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		665E97C012662C6A0025FA42 /* libThree20UINavigator-Xcode3.2.5.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libThree20UINavigator-Xcode3.2.5.a";
-			remoteRef = 665E97BF12662C6A0025FA42 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		665E97C412662C6A0025FA42 /* UINavigatorUnitTests-Xcode3.2.5.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "UINavigatorUnitTests-Xcode3.2.5.octest";
-			remoteRef = 665E97C312662C6A0025FA42 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		665E97CD12662C6A0025FA42 /* libThree20UI-Xcode3.2.5.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libThree20UI-Xcode3.2.5.a";
-			remoteRef = 665E97CC12662C6A0025FA42 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		665E97D112662C6A0025FA42 /* UIUnitTests-Xcode3.2.5.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "UIUnitTests-Xcode3.2.5.octest";
-			remoteRef = 665E97D012662C6A0025FA42 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		665E97DA12662C6A0025FA42 /* libThree20-Xcode3.2.5.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libThree20-Xcode3.2.5.a";
-			remoteRef = 665E97D912662C6A0025FA42 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		665E97DE12662C6A0025FA42 /* Three20UnitTests-Xcode3.2.5.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "Three20UnitTests-Xcode3.2.5.octest";
-			remoteRef = 665E97DD12662C6A0025FA42 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
 		6E37946E11B9B6300011C497 /* libThree20Core.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
@@ -956,17 +631,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		664DFD2912662D64004C20C2 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				664DFD2A12662D64004C20C2 /* Three20.bundle in Resources */,
-				664DFD2B12662D64004C20C2 /* Default.png in Resources */,
-				664DFD2C12662D64004C20C2 /* Icon.png in Resources */,
-				664DFD2D12662D64004C20C2 /* Default@2x.png in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -983,57 +647,9 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		664DFD2E12662D64004C20C2 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				664DFD2F12662D64004C20C2 /* main.m in Sources */,
-				664DFD3012662D64004C20C2 /* AppDelegate.m in Sources */,
-				664DFD3112662D64004C20C2 /* MainMenuViewController.m in Sources */,
-				664DFD3212662D64004C20C2 /* Atlas.m in Sources */,
-				664DFD3312662D64004C20C2 /* StyleViewController.m in Sources */,
-				664DFD3412662D64004C20C2 /* StyleView.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		664DFD6B12662D7D004C20C2 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Three20Network-Xcode3.2.5";
-			targetProxy = 664DFD6A12662D7D004C20C2 /* PBXContainerItemProxy */;
-		};
-		664DFD6D12662D7D004C20C2 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Three20Core-Xcode3.2.5";
-			targetProxy = 664DFD6C12662D7D004C20C2 /* PBXContainerItemProxy */;
-		};
-		664DFD6F12662D7D004C20C2 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Three20UI-Xcode3.2.5";
-			targetProxy = 664DFD6E12662D7D004C20C2 /* PBXContainerItemProxy */;
-		};
-		664DFD7112662D7D004C20C2 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Three20Style-Xcode3.2.5";
-			targetProxy = 664DFD7012662D7D004C20C2 /* PBXContainerItemProxy */;
-		};
-		664DFD7312662D7D004C20C2 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Three20UICommon-Xcode3.2.5";
-			targetProxy = 664DFD7212662D7D004C20C2 /* PBXContainerItemProxy */;
-		};
-		664DFD7512662D7D004C20C2 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Three20UINavigator-Xcode3.2.5";
-			targetProxy = 664DFD7412662D7D004C20C2 /* PBXContainerItemProxy */;
-		};
-		664DFD7712662D7D004C20C2 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Three20-Xcode3.2.5";
-			targetProxy = 664DFD7612662D7D004C20C2 /* PBXContainerItemProxy */;
-		};
 		6E37949811B9B64D0011C497 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Three20Network;
@@ -1093,47 +709,6 @@
 			};
 			name = Release;
 		};
-		664DFD4212662D64004C20C2 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6E850F4811B175FD0071A4FD /* App.xcconfig */;
-			buildSettings = {
-				COPY_PHASE_STRIP = NO;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
-				OTHER_LDFLAGS = (
-					"$(THREE20CORE325_LIB)",
-					"$(THREE20NETWORK325_LIB)",
-					"$(THREE20STYLE325_LIB)",
-					"$(THREE20UICOMMON325_LIB)",
-					"$(THREE20UINAVIGATOR325_LIB)",
-					"$(THREE20UI325_LIB)",
-					"$(THREE20325_LIB)",
-				);
-				PRODUCT_NAME = "$(BASE_PRODUCT_NAME)-Xcode3.2.5";
-				SDKROOT = iphoneos;
-			};
-			name = Debug;
-		};
-		664DFD4312662D64004C20C2 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6E850F4811B175FD0071A4FD /* App.xcconfig */;
-			buildSettings = {
-				COPY_PHASE_STRIP = YES;
-				OTHER_LDFLAGS = (
-					"$(THREE20CORE325_LIB)",
-					"$(THREE20NETWORK325_LIB)",
-					"$(THREE20STYLE325_LIB)",
-					"$(THREE20UICOMMON325_LIB)",
-					"$(THREE20UINAVIGATOR325_LIB)",
-					"$(THREE20UI325_LIB)",
-					"$(THREE20325_LIB)",
-				);
-				PRODUCT_NAME = "$(BASE_PRODUCT_NAME)-Xcode3.2.5";
-				SDKROOT = iphoneos;
-			};
-			name = Release;
-		};
 		C01FCF4F08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6E850F4911B175FD0071A4FD /* Project.xcconfig */;
@@ -1168,15 +743,6 @@
 			buildConfigurations = (
 				1D6058940D05DD3E006BFB54 /* Debug */,
 				1D6058950D05DD3E006BFB54 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		664DFD4112662D64004C20C2 /* Build configuration list for PBXNativeTarget "TTStyleCatalog-Xcode3.2.5" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				664DFD4212662D64004C20C2 /* Debug */,
-				664DFD4312662D64004C20C2 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/samples/TTTwitter/TTTwitter.xcodeproj/project.pbxproj
+++ b/samples/TTTwitter/TTTwitter.xcodeproj/project.pbxproj
@@ -12,28 +12,6 @@
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
 		1DF5F4E00D08C38300B7A737 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DF5F4DF0D08C38300B7A737 /* UIKit.framework */; };
 		288765FD0DF74451002DB57D /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288765FC0DF74451002DB57D /* CoreGraphics.framework */; };
-		667CFC0C12664DFD00BBCBFB /* Three20.bundle in Resources */ = {isa = PBXBuildFile; fileRef = EB383B6C10BBF6360000B2D2 /* Three20.bundle */; };
-		667CFC0D12664DFD00BBCBFB /* Default.png in Resources */ = {isa = PBXBuildFile; fileRef = 6E94C736116D985F0012B12C /* Default.png */; };
-		667CFC0E12664DFD00BBCBFB /* Icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 6E94C73C116D98920012B12C /* Icon.png */; };
-		667CFC1012664DFD00BBCBFB /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; };
-		667CFC1112664DFD00BBCBFB /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D3623250D0F684500981E51 /* AppDelegate.m */; };
-		667CFC1212664DFD00BBCBFB /* Atlas.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E10599B112CCCC400549F42 /* Atlas.m */; };
-		667CFC1312664DFD00BBCBFB /* TTTwitterSearchFeedViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E1059A9112CCF8400549F42 /* TTTwitterSearchFeedViewController.m */; };
-		667CFC1412664DFD00BBCBFB /* TTTwitterSearchFeedModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E1059AE112CCFAF00549F42 /* TTTwitterSearchFeedModel.m */; };
-		667CFC1512664DFD00BBCBFB /* TTTwitterSearchFeedDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E1059B2112CCFBB00549F42 /* TTTwitterSearchFeedDataSource.m */; };
-		667CFC1612664DFD00BBCBFB /* TTTwitterTweet.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E105AD1112CDBCC00549F42 /* TTTwitterTweet.m */; };
-		667CFC1812664DFD00BBCBFB /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
-		667CFC1912664DFD00BBCBFB /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DF5F4DF0D08C38300B7A737 /* UIKit.framework */; };
-		667CFC1A12664DFD00BBCBFB /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288765FC0DF74451002DB57D /* CoreGraphics.framework */; };
-		667CFC1B12664DFD00BBCBFB /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EB383B6410BBF62B0000B2D2 /* QuartzCore.framework */; };
-		667CFCEC12664F4400BBCBFB /* libThree20Core-Xcode3.2.5.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 665E9BB112664CFE0025FA42 /* libThree20Core-Xcode3.2.5.a */; };
-		667CFCED12664F4400BBCBFB /* libThree20Network-Xcode3.2.5.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 665E9BBE12664CFE0025FA42 /* libThree20Network-Xcode3.2.5.a */; };
-		667CFCEE12664F4400BBCBFB /* libThree20Style-Xcode3.2.5.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 665E9BCB12664CFE0025FA42 /* libThree20Style-Xcode3.2.5.a */; };
-		667CFCEF12664F4400BBCBFB /* libThree20UICommon-Xcode3.2.5.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 665E9BD812664CFE0025FA42 /* libThree20UICommon-Xcode3.2.5.a */; };
-		667CFCF012664F4400BBCBFB /* libThree20UINavigator-Xcode3.2.5.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 665E9BE512664CFE0025FA42 /* libThree20UINavigator-Xcode3.2.5.a */; };
-		667CFCF112664F4400BBCBFB /* libThree20UI-Xcode3.2.5.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 665E9BF212664CFE0025FA42 /* libThree20UI-Xcode3.2.5.a */; };
-		667CFCF212664F4400BBCBFB /* libThree20-Xcode3.2.5.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 665E9BFF12664CFE0025FA42 /* libThree20-Xcode3.2.5.a */; };
-		667CFCF312664F4400BBCBFB /* libextThree20JSON+YAJL-Xcode3.2.5.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 665E9C1312664CFE0025FA42 /* libextThree20JSON+YAJL-Xcode3.2.5.a */; };
 		6E10599C112CCCC400549F42 /* Atlas.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E10599B112CCCC400549F42 /* Atlas.m */; };
 		6E1059AA112CCF8400549F42 /* TTTwitterSearchFeedViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E1059A9112CCF8400549F42 /* TTTwitterSearchFeedViewController.m */; };
 		6E1059AF112CCFAF00549F42 /* TTTwitterSearchFeedModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E1059AE112CCFAF00549F42 /* TTTwitterSearchFeedModel.m */; };
@@ -54,181 +32,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		665E9BB012664CFE0025FA42 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E64630E1187E7D500F08CB1 /* Three20Core.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 6650CAA21262F6E2003FF804;
-			remoteInfo = "Three20Core-Xcode3.2.5";
-		};
-		665E9BB412664CFE0025FA42 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E64630E1187E7D500F08CB1 /* Three20Core.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 664961641262EE5000C2C80E;
-			remoteInfo = "Three20CoreUnitTests-Xcode3.2.5";
-		};
-		665E9BBD12664CFE0025FA42 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E6463171187E7E800F08CB1 /* Three20Network.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 662D81EF12630516005851C2;
-			remoteInfo = "Three20Network-Xcode3.2.5";
-		};
-		665E9BC112664CFE0025FA42 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E6463171187E7E800F08CB1 /* Three20Network.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 662D81B2126304EB005851C2;
-			remoteInfo = "Three20NetworkUnitTests-Xcode3.2.5";
-		};
-		665E9BCA12664CFE0025FA42 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E6463201187E7F000F08CB1 /* Three20Style.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 66C16BE912639E2700A7825A;
-			remoteInfo = "Three20Style-Xcode3.2.5";
-		};
-		665E9BCE12664CFE0025FA42 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E6463201187E7F000F08CB1 /* Three20Style.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 66C16C0112639E4500A7825A;
-			remoteInfo = "Three20StyleUnitTests-Xcode3.2.5";
-		};
-		665E9BD712664CFE0025FA42 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E877621118D0052001691E0 /* Three20UICommon.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 665A53761264D54B0032D0BE;
-			remoteInfo = "Three20UICommon-Xcode3.2.5";
-		};
-		665E9BDB12664CFE0025FA42 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E877621118D0052001691E0 /* Three20UICommon.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 665A53891264D54B0032D0BE;
-			remoteInfo = "Three20UICommonUnitTests-Xcode3.2.5";
-		};
-		665E9BE412664CFE0025FA42 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E87762A118D005A001691E0 /* Three20UINavigator.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 665A54521264DAF70032D0BE;
-			remoteInfo = "Three20UINavigator-Xcode3.2.5";
-		};
-		665E9BE812664CFE0025FA42 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E87762A118D005A001691E0 /* Three20UINavigator.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 665A54681264DAF70032D0BE;
-			remoteInfo = "Three20UINavigatorUnitTests-Xcode3.2.5";
-		};
-		665E9BF112664CFE0025FA42 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E6463291187E7F600F08CB1 /* Three20UI.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 66FC2BC81264E3A400F56B19;
-			remoteInfo = "Three20UI-Xcode3.2.5";
-		};
-		665E9BF512664CFE0025FA42 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E6463291187E7F600F08CB1 /* Three20UI.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 66FC2BE61264E3A500F56B19;
-			remoteInfo = "Three20UIUnitTests-Xcode3.2.5";
-		};
-		665E9BFE12664CFE0025FA42 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E3795E611B9B79C0011C497 /* Three20.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 665A55DE126521740032D0BE;
-			remoteInfo = "Three20-Xcode3.2.5";
-		};
-		665E9C0212664CFE0025FA42 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E3795E611B9B79C0011C497 /* Three20.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 665A55FB126521740032D0BE;
-			remoteInfo = "Three20UnitTests-Xcode3.2.5";
-		};
-		665E9C0E12664CFE0025FA42 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E6462DE1187E6C800F08CB1 /* extThree20JSON.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 66C34BB81266200600489E9A;
-			remoteInfo = "extThree20JSON+SBJSON-Xcode3.2.5";
-		};
-		665E9C1212664CFE0025FA42 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E6462DE1187E6C800F08CB1 /* extThree20JSON.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 66C34BE41266200600489E9A;
-			remoteInfo = "extThree20JSON+YAJL-Xcode3.2.5";
-		};
-		665E9C1612664CFE0025FA42 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E6462DE1187E6C800F08CB1 /* extThree20JSON.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 66C34BF91266200600489E9A;
-			remoteInfo = "extThree20JSONUnitTests+SBJSON-Xcode3.2.5";
-		};
-		667CFCDC12664F2900BBCBFB /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E87762A118D005A001691E0 /* Three20UINavigator.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 665A541D1264DAF70032D0BE;
-			remoteInfo = "Three20UINavigator-Xcode3.2.5";
-		};
-		667CFCDE12664F2900BBCBFB /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E6462DE1187E6C800F08CB1 /* extThree20JSON.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 66C34BB91266200600489E9A;
-			remoteInfo = "extThree20JSON+YAJL-Xcode3.2.5";
-		};
-		667CFCE012664F2900BBCBFB /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E64630E1187E7D500F08CB1 /* Three20Core.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 6650CA791262F6E2003FF804;
-			remoteInfo = "Three20Core-Xcode3.2.5";
-		};
-		667CFCE212664F2900BBCBFB /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E3795E611B9B79C0011C497 /* Three20.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 665A55C6126521740032D0BE;
-			remoteInfo = "Three20-Xcode3.2.5";
-		};
-		667CFCE412664F2900BBCBFB /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E6463201187E7F000F08CB1 /* Three20Style.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 66C16B6012639E2700A7825A;
-			remoteInfo = "Three20Style-Xcode3.2.5";
-		};
-		667CFCE612664F2900BBCBFB /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E877621118D0052001691E0 /* Three20UICommon.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 665A53601264D54B0032D0BE;
-			remoteInfo = "Three20UICommon-Xcode3.2.5";
-		};
-		667CFCE812664F2900BBCBFB /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E6463171187E7E800F08CB1 /* Three20Network.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 662D81C912630516005851C2;
-			remoteInfo = "Three20Network-Xcode3.2.5";
-		};
-		667CFCEA12664F2900BBCBFB /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E6463291187E7F600F08CB1 /* Three20UI.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 66FC2AB51264E3A400F56B19;
-			remoteInfo = "Three20UI-Xcode3.2.5";
-		};
 		6E3795EB11B9B79C0011C497 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 6E3795E611B9B79C0011C497 /* Three20.xcodeproj */;
@@ -414,7 +217,6 @@
 		1DF5F4DF0D08C38300B7A737 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		288765FC0DF74451002DB57D /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
-		667CFC2712664DFD00BBCBFB /* TTTwitter-Xcode3.2.5.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "TTTwitter-Xcode3.2.5.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6E10599A112CCCC400549F42 /* Atlas.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Atlas.h; sourceTree = "<group>"; };
 		6E10599B112CCCC400549F42 /* Atlas.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Atlas.m; sourceTree = "<group>"; };
 		6E1059A8112CCF8400549F42 /* TTTwitterSearchFeedViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TTTwitterSearchFeedViewController.h; sourceTree = "<group>"; };
@@ -466,25 +268,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		667CFC1712664DFD00BBCBFB /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				667CFCEC12664F4400BBCBFB /* libThree20Core-Xcode3.2.5.a in Frameworks */,
-				667CFCED12664F4400BBCBFB /* libThree20Network-Xcode3.2.5.a in Frameworks */,
-				667CFCEE12664F4400BBCBFB /* libThree20Style-Xcode3.2.5.a in Frameworks */,
-				667CFCEF12664F4400BBCBFB /* libThree20UICommon-Xcode3.2.5.a in Frameworks */,
-				667CFCF012664F4400BBCBFB /* libThree20UINavigator-Xcode3.2.5.a in Frameworks */,
-				667CFCF112664F4400BBCBFB /* libThree20UI-Xcode3.2.5.a in Frameworks */,
-				667CFCF212664F4400BBCBFB /* libThree20-Xcode3.2.5.a in Frameworks */,
-				667CFCF312664F4400BBCBFB /* libextThree20JSON+YAJL-Xcode3.2.5.a in Frameworks */,
-				667CFC1812664DFD00BBCBFB /* Foundation.framework in Frameworks */,
-				667CFC1912664DFD00BBCBFB /* UIKit.framework in Frameworks */,
-				667CFC1A12664DFD00BBCBFB /* CoreGraphics.framework in Frameworks */,
-				667CFC1B12664DFD00BBCBFB /* QuartzCore.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -504,7 +287,6 @@
 			isa = PBXGroup;
 			children = (
 				1D6058910D05DD3D006BFB54 /* TTTwitter.app */,
-				667CFC2712664DFD00BBCBFB /* TTTwitter-Xcode3.2.5.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -606,9 +388,7 @@
 			isa = PBXGroup;
 			children = (
 				6E3795EC11B9B79C0011C497 /* libThree20.a */,
-				665E9BFF12664CFE0025FA42 /* libThree20-Xcode3.2.5.a */,
 				6E3795EE11B9B79C0011C497 /* Three20UnitTests.octest */,
-				665E9C0312664CFE0025FA42 /* Three20UnitTests-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -659,11 +439,8 @@
 			isa = PBXGroup;
 			children = (
 				6E6462E51187E6C800F08CB1 /* libextThree20JSON+SBJSON.a */,
-				665E9C0F12664CFE0025FA42 /* libextThree20JSON+SBJSON-Xcode3.2.5.a */,
 				6E6462E71187E6C800F08CB1 /* libextThree20JSON+YAJL.a */,
-				665E9C1312664CFE0025FA42 /* libextThree20JSON+YAJL-Xcode3.2.5.a */,
 				6E6462E91187E6C800F08CB1 /* extJSONUnitTests+SBJSON.octest */,
-				665E9C1712664CFE0025FA42 /* extJSONUnitTests+SBJSON-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -672,9 +449,7 @@
 			isa = PBXGroup;
 			children = (
 				6E6463141187E7D500F08CB1 /* libThree20Core.a */,
-				665E9BB112664CFE0025FA42 /* libThree20Core-Xcode3.2.5.a */,
 				6E6463161187E7D500F08CB1 /* CoreUnitTests.octest */,
-				665E9BB512664CFE0025FA42 /* CoreUnitTests-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -683,9 +458,7 @@
 			isa = PBXGroup;
 			children = (
 				6E64631D1187E7E800F08CB1 /* libThree20Network.a */,
-				665E9BBE12664CFE0025FA42 /* libThree20Network-Xcode3.2.5.a */,
 				6E64631F1187E7E800F08CB1 /* NetworkUnitTests.octest */,
-				665E9BC212664CFE0025FA42 /* NetworkUnitTests-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -694,9 +467,7 @@
 			isa = PBXGroup;
 			children = (
 				6E6463261187E7F000F08CB1 /* libThree20Style.a */,
-				665E9BCB12664CFE0025FA42 /* libThree20Style-Xcode3.2.5.a */,
 				6E6463281187E7F000F08CB1 /* StyleUnitTests.octest */,
-				665E9BCF12664CFE0025FA42 /* StyleUnitTests-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -705,9 +476,7 @@
 			isa = PBXGroup;
 			children = (
 				6E64632F1187E7F600F08CB1 /* libThree20UI.a */,
-				665E9BF212664CFE0025FA42 /* libThree20UI-Xcode3.2.5.a */,
 				6E6463311187E7F600F08CB1 /* UIUnitTests.octest */,
-				665E9BF612664CFE0025FA42 /* UIUnitTests-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -716,9 +485,7 @@
 			isa = PBXGroup;
 			children = (
 				6E877627118D0052001691E0 /* libThree20UICommon.a */,
-				665E9BD812664CFE0025FA42 /* libThree20UICommon-Xcode3.2.5.a */,
 				6E877629118D0052001691E0 /* UICommonUnitTests.octest */,
-				665E9BDC12664CFE0025FA42 /* UICommonUnitTests-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -727,9 +494,7 @@
 			isa = PBXGroup;
 			children = (
 				6E877630118D005A001691E0 /* libThree20UINavigator.a */,
-				665E9BE512664CFE0025FA42 /* libThree20UINavigator-Xcode3.2.5.a */,
 				6E877632118D005A001691E0 /* UINavigatorUnitTests.octest */,
-				665E9BE912664CFE0025FA42 /* UINavigatorUnitTests-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -760,31 +525,6 @@
 			name = TTTwitter;
 			productName = TTTwitter;
 			productReference = 1D6058910D05DD3D006BFB54 /* TTTwitter.app */;
-			productType = "com.apple.product-type.application";
-		};
-		667CFBFA12664DFD00BBCBFB /* TTTwitter-Xcode3.2.5 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 667CFC2412664DFD00BBCBFB /* Build configuration list for PBXNativeTarget "TTTwitter-Xcode3.2.5" */;
-			buildPhases = (
-				667CFC0B12664DFD00BBCBFB /* Resources */,
-				667CFC0F12664DFD00BBCBFB /* Sources */,
-				667CFC1712664DFD00BBCBFB /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				667CFCDD12664F2900BBCBFB /* PBXTargetDependency */,
-				667CFCDF12664F2900BBCBFB /* PBXTargetDependency */,
-				667CFCE112664F2900BBCBFB /* PBXTargetDependency */,
-				667CFCE312664F2900BBCBFB /* PBXTargetDependency */,
-				667CFCE512664F2900BBCBFB /* PBXTargetDependency */,
-				667CFCE712664F2900BBCBFB /* PBXTargetDependency */,
-				667CFCE912664F2900BBCBFB /* PBXTargetDependency */,
-				667CFCEB12664F2900BBCBFB /* PBXTargetDependency */,
-			);
-			name = "TTTwitter-Xcode3.2.5";
-			productName = TTTwitter;
-			productReference = 667CFC2712664DFD00BBCBFB /* TTTwitter-Xcode3.2.5.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -841,131 +581,11 @@
 			projectRoot = "";
 			targets = (
 				1D6058900D05DD3D006BFB54 /* TTTwitter */,
-				667CFBFA12664DFD00BBCBFB /* TTTwitter-Xcode3.2.5 */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		665E9BB112664CFE0025FA42 /* libThree20Core-Xcode3.2.5.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libThree20Core-Xcode3.2.5.a";
-			remoteRef = 665E9BB012664CFE0025FA42 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		665E9BB512664CFE0025FA42 /* CoreUnitTests-Xcode3.2.5.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "CoreUnitTests-Xcode3.2.5.octest";
-			remoteRef = 665E9BB412664CFE0025FA42 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		665E9BBE12664CFE0025FA42 /* libThree20Network-Xcode3.2.5.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libThree20Network-Xcode3.2.5.a";
-			remoteRef = 665E9BBD12664CFE0025FA42 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		665E9BC212664CFE0025FA42 /* NetworkUnitTests-Xcode3.2.5.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "NetworkUnitTests-Xcode3.2.5.octest";
-			remoteRef = 665E9BC112664CFE0025FA42 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		665E9BCB12664CFE0025FA42 /* libThree20Style-Xcode3.2.5.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libThree20Style-Xcode3.2.5.a";
-			remoteRef = 665E9BCA12664CFE0025FA42 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		665E9BCF12664CFE0025FA42 /* StyleUnitTests-Xcode3.2.5.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "StyleUnitTests-Xcode3.2.5.octest";
-			remoteRef = 665E9BCE12664CFE0025FA42 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		665E9BD812664CFE0025FA42 /* libThree20UICommon-Xcode3.2.5.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libThree20UICommon-Xcode3.2.5.a";
-			remoteRef = 665E9BD712664CFE0025FA42 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		665E9BDC12664CFE0025FA42 /* UICommonUnitTests-Xcode3.2.5.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "UICommonUnitTests-Xcode3.2.5.octest";
-			remoteRef = 665E9BDB12664CFE0025FA42 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		665E9BE512664CFE0025FA42 /* libThree20UINavigator-Xcode3.2.5.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libThree20UINavigator-Xcode3.2.5.a";
-			remoteRef = 665E9BE412664CFE0025FA42 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		665E9BE912664CFE0025FA42 /* UINavigatorUnitTests-Xcode3.2.5.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "UINavigatorUnitTests-Xcode3.2.5.octest";
-			remoteRef = 665E9BE812664CFE0025FA42 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		665E9BF212664CFE0025FA42 /* libThree20UI-Xcode3.2.5.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libThree20UI-Xcode3.2.5.a";
-			remoteRef = 665E9BF112664CFE0025FA42 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		665E9BF612664CFE0025FA42 /* UIUnitTests-Xcode3.2.5.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "UIUnitTests-Xcode3.2.5.octest";
-			remoteRef = 665E9BF512664CFE0025FA42 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		665E9BFF12664CFE0025FA42 /* libThree20-Xcode3.2.5.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libThree20-Xcode3.2.5.a";
-			remoteRef = 665E9BFE12664CFE0025FA42 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		665E9C0312664CFE0025FA42 /* Three20UnitTests-Xcode3.2.5.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "Three20UnitTests-Xcode3.2.5.octest";
-			remoteRef = 665E9C0212664CFE0025FA42 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		665E9C0F12664CFE0025FA42 /* libextThree20JSON+SBJSON-Xcode3.2.5.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libextThree20JSON+SBJSON-Xcode3.2.5.a";
-			remoteRef = 665E9C0E12664CFE0025FA42 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		665E9C1312664CFE0025FA42 /* libextThree20JSON+YAJL-Xcode3.2.5.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libextThree20JSON+YAJL-Xcode3.2.5.a";
-			remoteRef = 665E9C1212664CFE0025FA42 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		665E9C1712664CFE0025FA42 /* extJSONUnitTests+SBJSON-Xcode3.2.5.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "extJSONUnitTests+SBJSON-Xcode3.2.5.octest";
-			remoteRef = 665E9C1612664CFE0025FA42 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
 		6E3795EC11B9B79C0011C497 /* libThree20.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
@@ -1098,16 +718,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		667CFC0B12664DFD00BBCBFB /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				667CFC0C12664DFD00BBCBFB /* Three20.bundle in Resources */,
-				667CFC0D12664DFD00BBCBFB /* Default.png in Resources */,
-				667CFC0E12664DFD00BBCBFB /* Icon.png in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -1125,63 +735,9 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		667CFC0F12664DFD00BBCBFB /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				667CFC1012664DFD00BBCBFB /* main.m in Sources */,
-				667CFC1112664DFD00BBCBFB /* AppDelegate.m in Sources */,
-				667CFC1212664DFD00BBCBFB /* Atlas.m in Sources */,
-				667CFC1312664DFD00BBCBFB /* TTTwitterSearchFeedViewController.m in Sources */,
-				667CFC1412664DFD00BBCBFB /* TTTwitterSearchFeedModel.m in Sources */,
-				667CFC1512664DFD00BBCBFB /* TTTwitterSearchFeedDataSource.m in Sources */,
-				667CFC1612664DFD00BBCBFB /* TTTwitterTweet.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		667CFCDD12664F2900BBCBFB /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Three20UINavigator-Xcode3.2.5";
-			targetProxy = 667CFCDC12664F2900BBCBFB /* PBXContainerItemProxy */;
-		};
-		667CFCDF12664F2900BBCBFB /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "extThree20JSON+YAJL-Xcode3.2.5";
-			targetProxy = 667CFCDE12664F2900BBCBFB /* PBXContainerItemProxy */;
-		};
-		667CFCE112664F2900BBCBFB /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Three20Core-Xcode3.2.5";
-			targetProxy = 667CFCE012664F2900BBCBFB /* PBXContainerItemProxy */;
-		};
-		667CFCE312664F2900BBCBFB /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Three20-Xcode3.2.5";
-			targetProxy = 667CFCE212664F2900BBCBFB /* PBXContainerItemProxy */;
-		};
-		667CFCE512664F2900BBCBFB /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Three20Style-Xcode3.2.5";
-			targetProxy = 667CFCE412664F2900BBCBFB /* PBXContainerItemProxy */;
-		};
-		667CFCE712664F2900BBCBFB /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Three20UICommon-Xcode3.2.5";
-			targetProxy = 667CFCE612664F2900BBCBFB /* PBXContainerItemProxy */;
-		};
-		667CFCE912664F2900BBCBFB /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Three20Network-Xcode3.2.5";
-			targetProxy = 667CFCE812664F2900BBCBFB /* PBXContainerItemProxy */;
-		};
-		667CFCEB12664F2900BBCBFB /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Three20UI-Xcode3.2.5";
-			targetProxy = 667CFCEA12664F2900BBCBFB /* PBXContainerItemProxy */;
-		};
 		6E37960111B9B7BF0011C497 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Three20;
@@ -1246,49 +802,6 @@
 			};
 			name = Release;
 		};
-		667CFC2512664DFD00BBCBFB /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6E6462D91187E6A900F08CB1 /* App.xcconfig */;
-			buildSettings = {
-				COPY_PHASE_STRIP = NO;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
-				OTHER_LDFLAGS = (
-					"$(THREE20CORE325_LIB)",
-					"$(THREE20NETWORK325_LIB)",
-					"$(THREE20STYLE325_LIB)",
-					"$(THREE20UICOMMON325_LIB)",
-					"$(THREE20UINAVIGATOR325_LIB)",
-					"$(THREE20UI325_LIB)",
-					"$(THREE20325_LIB)",
-					"$(EXTTHREE20JSONYAJL325_LIB)",
-				);
-				PRODUCT_NAME = "$(BASE_PRODUCT_NAME)-Xcode3.2.5";
-				SDKROOT = iphoneos;
-			};
-			name = Debug;
-		};
-		667CFC2612664DFD00BBCBFB /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6E6462D91187E6A900F08CB1 /* App.xcconfig */;
-			buildSettings = {
-				COPY_PHASE_STRIP = YES;
-				OTHER_LDFLAGS = (
-					"$(THREE20CORE325_LIB)",
-					"$(THREE20NETWORK325_LIB)",
-					"$(THREE20STYLE325_LIB)",
-					"$(THREE20UICOMMON325_LIB)",
-					"$(THREE20UINAVIGATOR325_LIB)",
-					"$(THREE20UI325_LIB)",
-					"$(THREE20325_LIB)",
-					"$(EXTTHREE20JSONYAJL325_LIB)",
-				);
-				PRODUCT_NAME = "$(BASE_PRODUCT_NAME)-Xcode3.2.5";
-				SDKROOT = iphoneos;
-			};
-			name = Release;
-		};
 		C01FCF4F08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6E6462DA1187E6A900F08CB1 /* Project.xcconfig */;
@@ -1323,15 +836,6 @@
 			buildConfigurations = (
 				1D6058940D05DD3E006BFB54 /* Debug */,
 				1D6058950D05DD3E006BFB54 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		667CFC2412664DFD00BBCBFB /* Build configuration list for PBXNativeTarget "TTTwitter-Xcode3.2.5" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				667CFC2512664DFD00BBCBFB /* Debug */,
-				667CFC2612664DFD00BBCBFB /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/samples/UI/TTNibDemo/TTNibDemo.xcodeproj/project.pbxproj
+++ b/samples/UI/TTNibDemo/TTNibDemo.xcodeproj/project.pbxproj
@@ -15,36 +15,6 @@
 		28AD73600D9D9599002E5188 /* MainWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 28AD735F0D9D9599002E5188 /* MainWindow.xib */; };
 		28C286E10D94DF7D0034E888 /* RootViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 28C286E00D94DF7D0034E888 /* RootViewController.m */; };
 		28F335F11007B36200424DE2 /* DemoTableViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 28F335F01007B36200424DE2 /* DemoTableViewController.xib */; };
-		669555AE126650DF00356FDC /* MainWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 28AD735F0D9D9599002E5188 /* MainWindow.xib */; };
-		669555AF126650DF00356FDC /* DemoTableViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 28F335F01007B36200424DE2 /* DemoTableViewController.xib */; };
-		669555B0126650DF00356FDC /* README.mdown in Resources */ = {isa = PBXBuildFile; fileRef = CC85D4B411681EC500D3FE00 /* README.mdown */; };
-		669555B1126650DF00356FDC /* FooterTableViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CC85D4D11168229C00D3FE00 /* FooterTableViewController.xib */; };
-		669555B2126650DF00356FDC /* DemoPostController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CC85D5F111682A2500D3FE00 /* DemoPostController.xib */; };
-		669555B3126650DF00356FDC /* DemoViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CC85D6D311682DC900D3FE00 /* DemoViewController.xib */; };
-		669555B4126650DF00356FDC /* blueArrow.png in Resources */ = {isa = PBXBuildFile; fileRef = CC85D6E511682E9B00D3FE00 /* blueArrow.png */; };
-		669555B5126650DF00356FDC /* DemoMessageController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CC85D724116830A300D3FE00 /* DemoMessageController.xib */; };
-		669555B6126650DF00356FDC /* Three20.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 6E60856611B0DFF900C93CD4 /* Three20.bundle */; };
-		669555B7126650DF00356FDC /* Default.png in Resources */ = {isa = PBXBuildFile; fileRef = 6E60858711B0E00800C93CD4 /* Default.png */; };
-		669555B8126650DF00356FDC /* Icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 6E60858811B0E00800C93CD4 /* Icon.png */; };
-		669555BA126650DF00356FDC /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; };
-		669555BB126650DF00356FDC /* NibDemoAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D3623250D0F684500981E51 /* NibDemoAppDelegate.m */; };
-		669555BC126650DF00356FDC /* RootViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 28C286E00D94DF7D0034E888 /* RootViewController.m */; };
-		669555BD126650DF00356FDC /* DemoTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = CC85CE021167E25200D3FE00 /* DemoTableViewController.m */; };
-		669555BE126650DF00356FDC /* DemoPostController.m in Sources */ = {isa = PBXBuildFile; fileRef = CC85D5F011682A2500D3FE00 /* DemoPostController.m */; };
-		669555BF126650DF00356FDC /* DemoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = CC85D6D211682DC900D3FE00 /* DemoViewController.m */; };
-		669555C0126650DF00356FDC /* DemoMessageController.m in Sources */ = {isa = PBXBuildFile; fileRef = CC85D723116830A300D3FE00 /* DemoMessageController.m */; };
-		669555C1126650DF00356FDC /* StyleSheet.m in Sources */ = {isa = PBXBuildFile; fileRef = CC85D8211168373300D3FE00 /* StyleSheet.m */; };
-		669555C3126650DF00356FDC /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
-		669555C4126650DF00356FDC /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DF5F4DF0D08C38300B7A737 /* UIKit.framework */; };
-		669555C5126650DF00356FDC /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2892E40F0DC94CBA00A64D0F /* CoreGraphics.framework */; };
-		669555C6126650DF00356FDC /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CC85CDA41167DF3B00D3FE00 /* QuartzCore.framework */; };
-		669556C91266514A00356FDC /* libThree20Core-Xcode3.2.5.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 66F950B91266507100BEF6F0 /* libThree20Core-Xcode3.2.5.a */; };
-		669556CA1266514A00356FDC /* libThree20Network-Xcode3.2.5.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 66F950C61266507100BEF6F0 /* libThree20Network-Xcode3.2.5.a */; };
-		669556CB1266514A00356FDC /* libThree20Style-Xcode3.2.5.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 66F950D31266507100BEF6F0 /* libThree20Style-Xcode3.2.5.a */; };
-		669556CC1266514A00356FDC /* libThree20UICommon-Xcode3.2.5.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 66F950E01266507100BEF6F0 /* libThree20UICommon-Xcode3.2.5.a */; };
-		669556CD1266514A00356FDC /* libThree20UINavigator-Xcode3.2.5.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 66F950ED1266507100BEF6F0 /* libThree20UINavigator-Xcode3.2.5.a */; };
-		669556CE1266514A00356FDC /* libThree20UI-Xcode3.2.5.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 66F950FA1266507100BEF6F0 /* libThree20UI-Xcode3.2.5.a */; };
-		669556CF1266514A00356FDC /* libThree20-Xcode3.2.5.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 66F951071266507100BEF6F0 /* libThree20-Xcode3.2.5.a */; };
 		6E37965B11B9B8460011C497 /* libThree20Core.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E37963A11B9B8400011C497 /* libThree20Core.a */; };
 		6E37965C11B9B8470011C497 /* libThree20Network.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E37964011B9B8400011C497 /* libThree20Network.a */; };
 		6E37965D11B9B8470011C497 /* libThree20Style.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E37964611B9B8400011C497 /* libThree20Style.a */; };
@@ -70,153 +40,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		669556981266513000356FDC /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37963411B9B8400011C497 /* Three20UI.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 66FC2AB51264E3A400F56B19;
-			remoteInfo = "Three20UI-Xcode3.2.5";
-		};
-		6695569A1266513000356FDC /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37962E11B9B8400011C497 /* Three20UICommon.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 665A53601264D54B0032D0BE;
-			remoteInfo = "Three20UICommon-Xcode3.2.5";
-		};
-		6695569C1266513000356FDC /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37962B11B9B8400011C497 /* Three20Style.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 66C16B6012639E2700A7825A;
-			remoteInfo = "Three20Style-Xcode3.2.5";
-		};
-		6695569E1266513000356FDC /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37962511B9B8400011C497 /* Three20Core.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 6650CA791262F6E2003FF804;
-			remoteInfo = "Three20Core-Xcode3.2.5";
-		};
-		669556A01266513000356FDC /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E60854811B0DED900C93CD4 /* Three20.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 665A55C6126521740032D0BE;
-			remoteInfo = "Three20-Xcode3.2.5";
-		};
-		669556A21266513000356FDC /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37963111B9B8400011C497 /* Three20UINavigator.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 665A541D1264DAF70032D0BE;
-			remoteInfo = "Three20UINavigator-Xcode3.2.5";
-		};
-		669556A41266513000356FDC /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37962811B9B8400011C497 /* Three20Network.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 662D81C912630516005851C2;
-			remoteInfo = "Three20Network-Xcode3.2.5";
-		};
-		66F950B81266507100BEF6F0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37962511B9B8400011C497 /* Three20Core.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 6650CAA21262F6E2003FF804;
-			remoteInfo = "Three20Core-Xcode3.2.5";
-		};
-		66F950BC1266507100BEF6F0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37962511B9B8400011C497 /* Three20Core.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 664961641262EE5000C2C80E;
-			remoteInfo = "Three20CoreUnitTests-Xcode3.2.5";
-		};
-		66F950C51266507100BEF6F0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37962811B9B8400011C497 /* Three20Network.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 662D81EF12630516005851C2;
-			remoteInfo = "Three20Network-Xcode3.2.5";
-		};
-		66F950C91266507100BEF6F0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37962811B9B8400011C497 /* Three20Network.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 662D81B2126304EB005851C2;
-			remoteInfo = "Three20NetworkUnitTests-Xcode3.2.5";
-		};
-		66F950D21266507100BEF6F0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37962B11B9B8400011C497 /* Three20Style.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 66C16BE912639E2700A7825A;
-			remoteInfo = "Three20Style-Xcode3.2.5";
-		};
-		66F950D61266507100BEF6F0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37962B11B9B8400011C497 /* Three20Style.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 66C16C0112639E4500A7825A;
-			remoteInfo = "Three20StyleUnitTests-Xcode3.2.5";
-		};
-		66F950DF1266507100BEF6F0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37962E11B9B8400011C497 /* Three20UICommon.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 665A53761264D54B0032D0BE;
-			remoteInfo = "Three20UICommon-Xcode3.2.5";
-		};
-		66F950E31266507100BEF6F0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37962E11B9B8400011C497 /* Three20UICommon.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 665A53891264D54B0032D0BE;
-			remoteInfo = "Three20UICommonUnitTests-Xcode3.2.5";
-		};
-		66F950EC1266507100BEF6F0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37963111B9B8400011C497 /* Three20UINavigator.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 665A54521264DAF70032D0BE;
-			remoteInfo = "Three20UINavigator-Xcode3.2.5";
-		};
-		66F950F01266507100BEF6F0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37963111B9B8400011C497 /* Three20UINavigator.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 665A54681264DAF70032D0BE;
-			remoteInfo = "Three20UINavigatorUnitTests-Xcode3.2.5";
-		};
-		66F950F91266507100BEF6F0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37963411B9B8400011C497 /* Three20UI.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 66FC2BC81264E3A400F56B19;
-			remoteInfo = "Three20UI-Xcode3.2.5";
-		};
-		66F950FD1266507100BEF6F0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E37963411B9B8400011C497 /* Three20UI.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 66FC2BE61264E3A500F56B19;
-			remoteInfo = "Three20UIUnitTests-Xcode3.2.5";
-		};
-		66F951061266507100BEF6F0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E60854811B0DED900C93CD4 /* Three20.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 665A55DE126521740032D0BE;
-			remoteInfo = "Three20-Xcode3.2.5";
-		};
-		66F9510A1266507100BEF6F0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6E60854811B0DED900C93CD4 /* Three20.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 665A55FB126521740032D0BE;
-			remoteInfo = "Three20UnitTests-Xcode3.2.5";
-		};
 		6E37963911B9B8400011C497 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 6E37962511B9B8400011C497 /* Three20Core.xcodeproj */;
@@ -379,7 +202,6 @@
 		28C286E00D94DF7D0034E888 /* RootViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RootViewController.m; sourceTree = "<group>"; };
 		28F335F01007B36200424DE2 /* DemoTableViewController.xib */ = {isa = PBXFileReference; explicitFileType = file.xib; path = DemoTableViewController.xib; sourceTree = "<group>"; };
 		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
-		669555D1126650DF00356FDC /* TTNibDemo-Xcode3.2.5.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "TTNibDemo-Xcode3.2.5.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6E37962511B9B8400011C497 /* Three20Core.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Three20Core.xcodeproj; path = ../../../src/Three20Core/Three20Core.xcodeproj; sourceTree = SOURCE_ROOT; };
 		6E37962811B9B8400011C497 /* Three20Network.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Three20Network.xcodeproj; path = ../../../src/Three20Network/Three20Network.xcodeproj; sourceTree = SOURCE_ROOT; };
 		6E37962B11B9B8400011C497 /* Three20Style.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Three20Style.xcodeproj; path = ../../../src/Three20Style/Three20Style.xcodeproj; sourceTree = SOURCE_ROOT; };
@@ -433,24 +255,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		669555C2126650DF00356FDC /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				669556C91266514A00356FDC /* libThree20Core-Xcode3.2.5.a in Frameworks */,
-				669556CA1266514A00356FDC /* libThree20Network-Xcode3.2.5.a in Frameworks */,
-				669556CB1266514A00356FDC /* libThree20Style-Xcode3.2.5.a in Frameworks */,
-				669556CC1266514A00356FDC /* libThree20UICommon-Xcode3.2.5.a in Frameworks */,
-				669556CD1266514A00356FDC /* libThree20UINavigator-Xcode3.2.5.a in Frameworks */,
-				669556CE1266514A00356FDC /* libThree20UI-Xcode3.2.5.a in Frameworks */,
-				669556CF1266514A00356FDC /* libThree20-Xcode3.2.5.a in Frameworks */,
-				669555C3126650DF00356FDC /* Foundation.framework in Frameworks */,
-				669555C4126650DF00356FDC /* UIKit.framework in Frameworks */,
-				669555C5126650DF00356FDC /* CoreGraphics.framework in Frameworks */,
-				669555C6126650DF00356FDC /* QuartzCore.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -469,7 +273,6 @@
 			isa = PBXGroup;
 			children = (
 				1D6058910D05DD3D006BFB54 /* TTNibDemo.app */,
-				669555D1126650DF00356FDC /* TTNibDemo-Xcode3.2.5.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -531,9 +334,7 @@
 			isa = PBXGroup;
 			children = (
 				6E37963A11B9B8400011C497 /* libThree20Core.a */,
-				66F950B91266507100BEF6F0 /* libThree20Core-Xcode3.2.5.a */,
 				6E37963C11B9B8400011C497 /* CoreUnitTests.octest */,
-				66F950BD1266507100BEF6F0 /* CoreUnitTests-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -542,9 +343,7 @@
 			isa = PBXGroup;
 			children = (
 				6E37964011B9B8400011C497 /* libThree20Network.a */,
-				66F950C61266507100BEF6F0 /* libThree20Network-Xcode3.2.5.a */,
 				6E37964211B9B8400011C497 /* NetworkUnitTests.octest */,
-				66F950CA1266507100BEF6F0 /* NetworkUnitTests-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -553,9 +352,7 @@
 			isa = PBXGroup;
 			children = (
 				6E37964611B9B8400011C497 /* libThree20Style.a */,
-				66F950D31266507100BEF6F0 /* libThree20Style-Xcode3.2.5.a */,
 				6E37964811B9B8400011C497 /* StyleUnitTests.octest */,
-				66F950D71266507100BEF6F0 /* StyleUnitTests-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -564,9 +361,7 @@
 			isa = PBXGroup;
 			children = (
 				6E37964C11B9B8400011C497 /* libThree20UICommon.a */,
-				66F950E01266507100BEF6F0 /* libThree20UICommon-Xcode3.2.5.a */,
 				6E37964E11B9B8400011C497 /* UICommonUnitTests.octest */,
-				66F950E41266507100BEF6F0 /* UICommonUnitTests-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -575,9 +370,7 @@
 			isa = PBXGroup;
 			children = (
 				6E37965211B9B8400011C497 /* libThree20UINavigator.a */,
-				66F950ED1266507100BEF6F0 /* libThree20UINavigator-Xcode3.2.5.a */,
 				6E37965411B9B8400011C497 /* UINavigatorUnitTests.octest */,
-				66F950F11266507100BEF6F0 /* UINavigatorUnitTests-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -586,9 +379,7 @@
 			isa = PBXGroup;
 			children = (
 				6E37965811B9B8400011C497 /* libThree20UI.a */,
-				66F950FA1266507100BEF6F0 /* libThree20UI-Xcode3.2.5.a */,
 				6E37965A11B9B8400011C497 /* UIUnitTests.octest */,
-				66F950FE1266507100BEF6F0 /* UIUnitTests-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -630,9 +421,7 @@
 			isa = PBXGroup;
 			children = (
 				6E60855711B0DED900C93CD4 /* libThree20.a */,
-				66F951071266507100BEF6F0 /* libThree20-Xcode3.2.5.a */,
 				6E60855911B0DED900C93CD4 /* Three20UnitTests.octest */,
-				66F9510B1266507100BEF6F0 /* Three20UnitTests-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -738,30 +527,6 @@
 			productReference = 1D6058910D05DD3D006BFB54 /* TTNibDemo.app */;
 			productType = "com.apple.product-type.application";
 		};
-		6695559E126650DF00356FDC /* TTNibDemo-Xcode3.2.5 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 669555CE126650DF00356FDC /* Build configuration list for PBXNativeTarget "TTNibDemo-Xcode3.2.5" */;
-			buildPhases = (
-				669555AD126650DF00356FDC /* Resources */,
-				669555B9126650DF00356FDC /* Sources */,
-				669555C2126650DF00356FDC /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				669556991266513000356FDC /* PBXTargetDependency */,
-				6695569B1266513000356FDC /* PBXTargetDependency */,
-				6695569D1266513000356FDC /* PBXTargetDependency */,
-				6695569F1266513000356FDC /* PBXTargetDependency */,
-				669556A11266513000356FDC /* PBXTargetDependency */,
-				669556A31266513000356FDC /* PBXTargetDependency */,
-				669556A51266513000356FDC /* PBXTargetDependency */,
-			);
-			name = "TTNibDemo-Xcode3.2.5";
-			productName = TTNibDemo;
-			productReference = 669555D1126650DF00356FDC /* TTNibDemo-Xcode3.2.5.app */;
-			productType = "com.apple.product-type.application";
-		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -816,110 +581,11 @@
 			projectRoot = "";
 			targets = (
 				1D6058900D05DD3D006BFB54 /* TTNibDemo */,
-				6695559E126650DF00356FDC /* TTNibDemo-Xcode3.2.5 */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		66F950B91266507100BEF6F0 /* libThree20Core-Xcode3.2.5.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libThree20Core-Xcode3.2.5.a";
-			remoteRef = 66F950B81266507100BEF6F0 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		66F950BD1266507100BEF6F0 /* CoreUnitTests-Xcode3.2.5.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "CoreUnitTests-Xcode3.2.5.octest";
-			remoteRef = 66F950BC1266507100BEF6F0 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		66F950C61266507100BEF6F0 /* libThree20Network-Xcode3.2.5.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libThree20Network-Xcode3.2.5.a";
-			remoteRef = 66F950C51266507100BEF6F0 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		66F950CA1266507100BEF6F0 /* NetworkUnitTests-Xcode3.2.5.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "NetworkUnitTests-Xcode3.2.5.octest";
-			remoteRef = 66F950C91266507100BEF6F0 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		66F950D31266507100BEF6F0 /* libThree20Style-Xcode3.2.5.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libThree20Style-Xcode3.2.5.a";
-			remoteRef = 66F950D21266507100BEF6F0 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		66F950D71266507100BEF6F0 /* StyleUnitTests-Xcode3.2.5.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "StyleUnitTests-Xcode3.2.5.octest";
-			remoteRef = 66F950D61266507100BEF6F0 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		66F950E01266507100BEF6F0 /* libThree20UICommon-Xcode3.2.5.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libThree20UICommon-Xcode3.2.5.a";
-			remoteRef = 66F950DF1266507100BEF6F0 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		66F950E41266507100BEF6F0 /* UICommonUnitTests-Xcode3.2.5.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "UICommonUnitTests-Xcode3.2.5.octest";
-			remoteRef = 66F950E31266507100BEF6F0 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		66F950ED1266507100BEF6F0 /* libThree20UINavigator-Xcode3.2.5.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libThree20UINavigator-Xcode3.2.5.a";
-			remoteRef = 66F950EC1266507100BEF6F0 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		66F950F11266507100BEF6F0 /* UINavigatorUnitTests-Xcode3.2.5.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "UINavigatorUnitTests-Xcode3.2.5.octest";
-			remoteRef = 66F950F01266507100BEF6F0 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		66F950FA1266507100BEF6F0 /* libThree20UI-Xcode3.2.5.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libThree20UI-Xcode3.2.5.a";
-			remoteRef = 66F950F91266507100BEF6F0 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		66F950FE1266507100BEF6F0 /* UIUnitTests-Xcode3.2.5.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "UIUnitTests-Xcode3.2.5.octest";
-			remoteRef = 66F950FD1266507100BEF6F0 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		66F951071266507100BEF6F0 /* libThree20-Xcode3.2.5.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libThree20-Xcode3.2.5.a";
-			remoteRef = 66F951061266507100BEF6F0 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		66F9510B1266507100BEF6F0 /* Three20UnitTests-Xcode3.2.5.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "Three20UnitTests-Xcode3.2.5.octest";
-			remoteRef = 66F9510A1266507100BEF6F0 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
 		6E37963A11B9B8400011C497 /* libThree20Core.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
@@ -1039,24 +705,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		669555AD126650DF00356FDC /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				669555AE126650DF00356FDC /* MainWindow.xib in Resources */,
-				669555AF126650DF00356FDC /* DemoTableViewController.xib in Resources */,
-				669555B0126650DF00356FDC /* README.mdown in Resources */,
-				669555B1126650DF00356FDC /* FooterTableViewController.xib in Resources */,
-				669555B2126650DF00356FDC /* DemoPostController.xib in Resources */,
-				669555B3126650DF00356FDC /* DemoViewController.xib in Resources */,
-				669555B4126650DF00356FDC /* blueArrow.png in Resources */,
-				669555B5126650DF00356FDC /* DemoMessageController.xib in Resources */,
-				669555B6126650DF00356FDC /* Three20.bundle in Resources */,
-				669555B7126650DF00356FDC /* Default.png in Resources */,
-				669555B8126650DF00356FDC /* Icon.png in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -1075,59 +723,9 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		669555B9126650DF00356FDC /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				669555BA126650DF00356FDC /* main.m in Sources */,
-				669555BB126650DF00356FDC /* NibDemoAppDelegate.m in Sources */,
-				669555BC126650DF00356FDC /* RootViewController.m in Sources */,
-				669555BD126650DF00356FDC /* DemoTableViewController.m in Sources */,
-				669555BE126650DF00356FDC /* DemoPostController.m in Sources */,
-				669555BF126650DF00356FDC /* DemoViewController.m in Sources */,
-				669555C0126650DF00356FDC /* DemoMessageController.m in Sources */,
-				669555C1126650DF00356FDC /* StyleSheet.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		669556991266513000356FDC /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Three20UI-Xcode3.2.5";
-			targetProxy = 669556981266513000356FDC /* PBXContainerItemProxy */;
-		};
-		6695569B1266513000356FDC /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Three20UICommon-Xcode3.2.5";
-			targetProxy = 6695569A1266513000356FDC /* PBXContainerItemProxy */;
-		};
-		6695569D1266513000356FDC /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Three20Style-Xcode3.2.5";
-			targetProxy = 6695569C1266513000356FDC /* PBXContainerItemProxy */;
-		};
-		6695569F1266513000356FDC /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Three20Core-Xcode3.2.5";
-			targetProxy = 6695569E1266513000356FDC /* PBXContainerItemProxy */;
-		};
-		669556A11266513000356FDC /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Three20-Xcode3.2.5";
-			targetProxy = 669556A01266513000356FDC /* PBXContainerItemProxy */;
-		};
-		669556A31266513000356FDC /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Three20UINavigator-Xcode3.2.5";
-			targetProxy = 669556A21266513000356FDC /* PBXContainerItemProxy */;
-		};
-		669556A51266513000356FDC /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Three20Network-Xcode3.2.5";
-			targetProxy = 669556A41266513000356FDC /* PBXContainerItemProxy */;
-		};
 		6E37966511B9B87B0011C497 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Three20UINavigator;
@@ -1186,46 +784,6 @@
 			};
 			name = Release;
 		};
-		669555CF126650DF00356FDC /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6E6084F311B0DEA600C93CD4 /* App.xcconfig */;
-			buildSettings = {
-				COPY_PHASE_STRIP = NO;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				OTHER_LDFLAGS = (
-					"$(THREE20CORE325_LIB)",
-					"$(THREE20NETWORK325_LIB)",
-					"$(THREE20STYLE325_LIB)",
-					"$(THREE20UICOMMON325_LIB)",
-					"$(THREE20UINAVIGATOR325_LIB)",
-					"$(THREE20UI325_LIB)",
-					"$(THREE20325_LIB)",
-				);
-				PRODUCT_NAME = "$(BASE_PRODUCT_NAME)-Xcode3.2.5";
-				SDKROOT = iphoneos;
-			};
-			name = Debug;
-		};
-		669555D0126650DF00356FDC /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6E6084F311B0DEA600C93CD4 /* App.xcconfig */;
-			buildSettings = {
-				COPY_PHASE_STRIP = YES;
-				OTHER_LDFLAGS = (
-					"$(THREE20CORE325_LIB)",
-					"$(THREE20NETWORK325_LIB)",
-					"$(THREE20STYLE325_LIB)",
-					"$(THREE20UICOMMON325_LIB)",
-					"$(THREE20UINAVIGATOR325_LIB)",
-					"$(THREE20UI325_LIB)",
-					"$(THREE20325_LIB)",
-				);
-				PRODUCT_NAME = "$(BASE_PRODUCT_NAME)-Xcode3.2.5";
-				SDKROOT = iphoneos;
-			};
-			name = Release;
-		};
 		C01FCF4F08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6E6084F411B0DEA600C93CD4 /* Project.xcconfig */;
@@ -1260,15 +818,6 @@
 			buildConfigurations = (
 				1D6058940D05DD3E006BFB54 /* Debug */,
 				1D6058950D05DD3E006BFB54 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		669555CE126650DF00356FDC /* Build configuration list for PBXNativeTarget "TTNibDemo-Xcode3.2.5" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				669555CF126650DF00356FDC /* Debug */,
-				669555D0126650DF00356FDC /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;


### PR DESCRIPTION
The oldest Xcode we are going to support going forward is Xcode 3.2.5. This will greatly simplify our project settings and structure thanks to the new "Latest iOS" flag in the settings.
