### PR TITLE
Fix 32 64 bit compiler warnings

### DIFF
--- a/src/Three20Style/Headers/TTGlobalStyle.h
+++ b/src/Three20Style/Headers/TTGlobalStyle.h
@@ -31,14 +31,14 @@ extern const CGFloat ttkRounded;
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Color helpers
 
-#define RGBCOLOR(r,g,b) [UIColor colorWithRed:(r)/255.0 green:(g)/255.0 blue:(b)/255.0 alpha:1]
-#define RGBACOLOR(r,g,b,a) [UIColor colorWithRed:(r)/255.0 green:(g)/255.0 blue:(b)/255.0 \
+#define RGBCOLOR(r,g,b) [UIColor colorWithRed:(r)/255.0f green:(g)/255.0f blue:(b)/255.0f alpha:1]
+#define RGBACOLOR(r,g,b,a) [UIColor colorWithRed:(r)/255.0f green:(g)/255.0f blue:(b)/255.0f \
 alpha:(a)]
 
 #define HSVCOLOR(h,s,v) [UIColor colorWithHue:(h) saturation:(s) value:(v) alpha:1]
 #define HSVACOLOR(h,s,v,a) [UIColor colorWithHue:(h) saturation:(s) value:(v) alpha:(a)]
 
-#define RGBA(r,g,b,a) (r)/255.0, (g)/255.0, (b)/255.0, (a)
+#define RGBA(r,g,b,a) (r)/255.0f, (g)/255.0f, (b)/255.0f, (a)
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Style helpers


### PR DESCRIPTION
those should be floats, not doubles

warning text:
"warning: implicit conversion shortens 64-bit value into a 32-bit value"
