### PR TITLE
TTPostController fix calls to super view controller's view appear/disappear methods, replaces pull request #403

### DIFF
--- a/src/Three20UI/Sources/TTPostController.m
+++ b/src/Three20UI/Sources/TTPostController.m
@@ -203,9 +203,18 @@ static const CGFloat kMarginY = 6;
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-- (void)showInViewDidFinishAnimated:(BOOL)animated {
+- (void)showInViewDidFinish:(BOOL)animated {
   [self.superController viewDidDisappear:animated];
 }
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)dismissViewDidFinish:(BOOL)animated {
+  [self.view removeFromSuperview];
+  [self.superController viewDidAppear:animated];
+  [self release];
+}
+
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)showAnimationDidStop {
@@ -252,7 +261,10 @@ static const CGFloat kMarginY = 6;
     [_delegate postControllerDidCancel:self];
   }
 
-  [self dismissPopupViewControllerAnimated:YES];
+  BOOL animated = YES;
+  
+  [self.superController viewWillAppear:animated];
+  [self dismissPopupViewControllerAnimated:animated];
 }
 
 
@@ -375,7 +387,15 @@ static const CGFloat kMarginY = 6;
 - (void)keyboardDidAppear:(BOOL)animated withBounds:(CGRect)bounds {
   [super keyboardDidAppear:animated withBounds:bounds];
   
-  [self showInViewDidFinishAnimated:animated];
+  [self showInViewDidFinish:animated];
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)keyboardDidDisappear:(BOOL)animated withBounds:(CGRect)bounds {
+  [super keyboardDidDisappear:animated withBounds:bounds];
+  
+  [self dismissViewDidFinish:animated];
 }
 
 
@@ -455,14 +475,6 @@ static const CGFloat kMarginY = 6;
 - (void)dismissPopupViewControllerAnimated:(BOOL)animated {
   if (animated) {
     [self fadeOut];
-
-  } else {
-    UIViewController* superController = self.superController;
-    [self.view removeFromSuperview];
-    [self release];
-    superController.popupViewController = nil;
-    [superController viewWillAppear:animated];
-    [superController viewDidAppear:animated];
   }
 }
 
@@ -550,6 +562,8 @@ static const CGFloat kMarginY = 6;
   [_result release];
   _result = [result retain];
 
+  [self.superController viewWillAppear:animated];
+  
   if (animated) {
     if ([_delegate respondsToSelector:@selector(postController:willAnimateTowards:)]) {
       CGRect rect = [_delegate postController:self willAnimateTowards:_originRect];

--- a/src/Three20UI/Sources/TTPostController.m
+++ b/src/Three20UI/Sources/TTPostController.m
@@ -68,6 +68,7 @@ static const CGFloat kMarginY = 6;
                                         style: UIBarButtonItemStyleDone
                                        target: self
                                        action: @selector(post)] autorelease];
+    self.autoresizesForKeyboard = YES;
   }
 
   return self;
@@ -200,6 +201,11 @@ static const CGFloat kMarginY = 6;
   _textView.hidden = NO;
 }
 
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)showInViewDidFinishAnimated:(BOOL)animated {
+  [self.superController viewDidDisappear:animated];
+}
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)showAnimationDidStop {
@@ -362,12 +368,29 @@ static const CGFloat kMarginY = 6;
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark -
+#pragma mark TTBaseViewController
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)keyboardDidAppear:(BOOL)animated withBounds:(CGRect)bounds {
+  [super keyboardDidAppear:animated withBounds:bounds];
+  
+  [self showInViewDidFinishAnimated:animated];
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark -
 #pragma mark TTPopupViewController
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)showInView:(UIView*)view animated:(BOOL)animated {
   [self retain];
+  
+  [self.superController viewWillDisappear:animated];
+  
   UIWindow* window = view.window ? view.window : [UIApplication sharedApplication].keyWindow;
 
   self.view.transform = [self transformForOrientation];


### PR DESCRIPTION
Replacement for pull request #403.

This pull request adds a call to the super view controller's viewDidDisappear: after the animation stops (after the keyboard appears).

This request also changes when the super view controller's viewWillAppear: method is called, viewWillAppear: is now called before any animation starts and the super view controller's viewDidAppear: method is now called after the animation stops (after the keyboard disappears).
