### PR TITLE
[UICommon] Change TTBaseViewController to use [UIApplication sharedApplication] statusBarStyle] instead of hardcoded UIStatusBarStyleDefault

### DIFF
--- a/src/Three20UICommon/Sources/TTBaseViewController.m
+++ b/src/Three20UICommon/Sources/TTBaseViewController.m
@@ -46,7 +46,7 @@
 - (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
   if (self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil]) {
     _navigationBarStyle = UIBarStyleDefault;
-    _statusBarStyle = UIStatusBarStyleDefault;
+    _statusBarStyle = [[UIApplication sharedApplication] statusBarStyle];
   }
 
   return self;


### PR DESCRIPTION
Before this change, TTBaseViewController was hardcoded to set the statusBarStyle to UIStatusBarStyleDefault.  This meant that an application had to change the UIStatusBarStyle in the info.plist file and in every subclass of TTBaseViewController.

With this change, the application only needs to set the UIStatusBarStyle in the info.plist and all view will use the setting, unless explicitly overridden.
