### PR TITLE
Hotfix openURLFromButton: crash

### DIFF
--- a/src/Three20UINavigator/Headers/TTBaseNavigator.h
+++ b/src/Three20UINavigator/Headers/TTBaseNavigator.h
@@ -164,6 +164,12 @@
  * with the top-most controller that contains this view that /isn't/ the container.
  * If getNavigatorForController: returns a navigator, this navigator is returned.
  * Otherwise, the global navigator is returned.
+ *
+ * If the given view is not, in fact, a view, which is the case if a UIBarButtonItem is passed,
+ * returns the global navigator via [TTBaseNavigator globalNavigator].
+ *
+ * If you need to use a specific navigator for UIBarButtonItem, handle the button tap
+ * yourself and use navigatorForView: on an actual view in the controller.
  */
 + (TTBaseNavigator*)navigatorForView:(UIView*)view;
 

--- a/src/Three20UINavigator/Sources/TTBaseNavigator.m
+++ b/src/Three20UINavigator/Sources/TTBaseNavigator.m
@@ -127,6 +127,12 @@ __attribute__((weak_import));
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 + (TTBaseNavigator*)navigatorForView:(UIView*)view {
+  // If this is called with a UIBarButtonItem, we can't traverse a view hierarchy to find the
+  // navigator, return the global navigator as a fallback.
+  if (![view isKindOfClass:[UIView class]]) {
+    return [TTBaseNavigator globalNavigator];
+  }
+
   id<TTNavigatorRootContainer>  container = nil;
   UIViewController*             controller = nil;      // The iterator.
   UIViewController*             childController = nil; // The last iterated controller.


### PR DESCRIPTION
When using openURLFromButton: we will likely be calling this from a
UIBarButtonItem object, which isn't a descendant of the UIView class.

We return the global navigator because there's no simple way
to determine the class from the bar button item. This is a
trade-off of ease-of-use over proper functionality here. If you want
to get a UIBarButtonItem to open a specific navigator, handle the
button tapped method yourself and get the correct navigator.
