### PR TITLE
Fix for TTTextEditor doubling first newline

### DIFF
--- a/src/Three20UI/Sources/TTTextEditor.m
+++ b/src/Three20UI/Sources/TTTextEditor.m
@@ -237,7 +237,7 @@ static const CGFloat kUITextViewVerticalPadding = 6;
     [self createTextView];
     _textField.hidden = YES;
     _textView.hidden = NO;
-    _textView.text = [_textField.text stringByAppendingString:@"\n"];
+    _textView.text = _textField.text;
     _internal.ignoreBeginAndEnd = YES;
     [_textView becomeFirstResponder];
     [self performSelector:@selector(stopIgnoringBeginAndEnd) withObject:nil afterDelay:0];


### PR DESCRIPTION
I can't believe that this fix is so simple and that bug hanging around for years...
I suspect this `\n` addition to be there for one strange reason.
Then I would recommend more testing, but that does fix the TTCatalog table control item sample.
Related bugtracker issue : #317
