### PR TITLE
Xcode 4 support

### DIFF
--- a/src/common/Configurations/Library.xcconfig
+++ b/src/common/Configurations/Library.xcconfig
@@ -22,6 +22,10 @@ GCC_PRECOMPILE_PREFIX_HEADER  = YES
 GCC_PREFIX_HEADER             = $(SRCROOT)/Headers/$(BASE_PRODUCT_NAME)_Prefix.pch
 RUN_CLANG_STATIC_ANALYZER     = NO
 
+// Don't include the Three20 libraries in the archive. This makes it possible to build IPAs
+// in Xcode 4.
+SKIP_INSTALL = YES
+
 // Uncomment this flags to build the modules with LLVM compiler 1.5
 //GCC_VERSION = com.apple.compilers.llvm.clang.1_0
 

--- a/src/common/Configurations/Paths.xcconfig
+++ b/src/common/Configurations/Paths.xcconfig
@@ -23,5 +23,19 @@ SYMROOT = $(OBJROOT)/Products
 // Search Paths
 
 LIBRARY_SEARCH_PATHS    = $(STDLIB_LIBRARY)
-HEADER_SEARCH_PATHS     = $(STDLIB_HEADERS) "$(CONFIGURATION_BUILD_DIR)/../three20"
 
+// Header search paths: why we have three
+//
+// CONFIGURATION_BUILD_DIR is for when the headers are copied to Three20's Build folder.
+// Applies to:
+//  - Xcode 3.2.#
+//  - Xcode 4 with the Build Location preference set to "Place build products in locations
+//    specified by targets"
+//
+// BUILT_PRODUCTS_DIR is for Xcode 4 support only. We need two copies of a BUILT_PRODUCTS_DIR path
+//                    because on Archive builds, there is one extra folder placed between the
+//                    product and the public header path.
+// Applies to:
+//  - Xcode 4 only
+
+HEADER_SEARCH_PATHS     = $(STDLIB_HEADERS) "$(BUILT_PRODUCTS_DIR)/../three20" "$(BUILT_PRODUCTS_DIR)/../../three20" "$(CONFIGURATION_BUILD_DIR)/../../three20"

--- a/src/scripts/Pbxproj.py
+++ b/src/scripts/Pbxproj.py
@@ -459,7 +459,7 @@ class Pbxproj(object):
 						project_data = project_data[:settings_start] + build_settings + project_data[settings_end:]
 			else:
 				# One
-				if search_paths != value:
+				if search_paths.strip('"') != value.strip('"'):
 					existing_path = search_paths
 					path_set = '(\n\t\t\t\t\t'+value+',\n\t\t\t\t\t'+existing_path+'\n\t\t\t\t)'
 					build_settings = build_settings[:match.start(1)] + path_set + build_settings[match.end(1):]

--- a/src/scripts/Pbxproj.py
+++ b/src/scripts/Pbxproj.py
@@ -363,6 +363,10 @@ class Pbxproj(object):
 	#
 	# <guid> /* <name> */,
 	def add_file_to_resources(self, name, guid):
+		match = re.search('\/\* '+re.escape('Resources')+' \*\/ = \{\n[ \t]+isa = PBXGroup;\n[ \t]+children = \(\n((?:.|\n)+?)\);', self.get_project_data())
+		if not match:
+			return self.add_file_to_group(name, guid, 'Supporting Files')
+
 		return self.add_file_to_group(name, guid, 'Resources')
 
 	def add_file_to_phase(self, name, guid, phase_guid, phase):
@@ -474,7 +478,7 @@ class Pbxproj(object):
 	def add_framework(self, framework):
 		tthash_base = self.get_hash_base(framework)
 		
-		fileref_hash = self.add_filereference(framework, 'frameworks', tthash_base+'0', 'System/Library/Frameworks/'+framework, 'SDK_ROOT')
+		fileref_hash = self.add_filereference(framework, 'frameworks', tthash_base+'0', 'System/Library/Frameworks/'+framework, 'SDKROOT')
 		libfile_hash = self.add_buildfile(framework, fileref_hash, tthash_base+'1')
 		if not self.add_file_to_frameworks(framework, fileref_hash):
 			return False

--- a/src/scripts/Pbxproj.py
+++ b/src/scripts/Pbxproj.py
@@ -68,9 +68,9 @@ def relpath(p1, p2):
 class Pbxproj(object):
 
 	@staticmethod
-	def get_pbxproj_by_name(name):
+	def get_pbxproj_by_name(name, xcode_version = None):
 		if name not in pbxproj_cache:
-			pbxproj_cache[name] = Pbxproj(name)
+			pbxproj_cache[name] = Pbxproj(name, xcode_version = xcode_version)
 
 		return pbxproj_cache[name]
 
@@ -78,7 +78,7 @@ class Pbxproj(object):
 	# Three20
 	# Three20:Three20-Xcode3.2.5
 	# /path/to/project.xcodeproj/project.pbxproj
-	def __init__(self, name):
+	def __init__(self, name, xcode_version = None):
 		self._project_data = None
 
 		parts = name.split(':')
@@ -105,6 +105,7 @@ class Pbxproj(object):
 
 		self._guid = None
 		self._deps = None
+		self._xcode_version = xcode_version
 		self._projectVersion = None
 		self.guid()
 
@@ -441,7 +442,11 @@ class Pbxproj(object):
 			return did_add_build_setting
 		
 		# Version 46 is Xcode 4's file format.
-		if self._projectVersion >= 46:
+		try:
+			primary_version = int(self._xcode_version.split('.')[0])
+		except ValueError, e:
+			primary_version = 0
+		if self._projectVersion >= 46 or primary_version >= 4:
 			did_add_build_setting = self.add_build_setting(configuration, 'HEADER_SEARCH_PATHS', '"$(BUILT_PRODUCTS_DIR)/../../three20"')
 			if not did_add_build_setting:
 				return did_add_build_setting

--- a/src/scripts/Protect.command
+++ b/src/scripts/Protect.command
@@ -22,7 +22,7 @@ IFS=$'\n'
 
 # In Xcode 4 Archive builds, there is one extra folder placed between the configuration build
 # dir and the public headers path titled "ArchiveIntermediates".
-if [[ $CONFIGURATION_BUILD_DIR == *ArchiveIntermediates* ]]; then
+if [[ "$DEPLOYMENT_LOCATION" == "YES" && "$XCODE_VERSION_MAJOR" -ge "0400" ]]; then
   cd ${CONFIGURATION_BUILD_DIR}/..${PUBLIC_HEADERS_FOLDER_PATH}
 else
   cd ${CONFIGURATION_BUILD_DIR}${PUBLIC_HEADERS_FOLDER_PATH}

--- a/src/scripts/Protect.command
+++ b/src/scripts/Protect.command
@@ -20,7 +20,13 @@
 # Ignore whitespace characters in paths
 IFS=$'\n'
 
-cd ${CONFIGURATION_BUILD_DIR}${PUBLIC_HEADERS_FOLDER_PATH}
+# In Xcode 4 Archive builds, there is one extra folder placed between the configuration build
+# dir and the public headers path titled "ArchiveIntermediates".
+if [[ $CONFIGURATION_BUILD_DIR == *ArchiveIntermediates* ]]; then
+  cd ${CONFIGURATION_BUILD_DIR}/..${PUBLIC_HEADERS_FOLDER_PATH}
+else
+  cd ${CONFIGURATION_BUILD_DIR}${PUBLIC_HEADERS_FOLDER_PATH}
+fi
 
 chmod a-w *.h 2>> /dev/null
 chmod a-w private/*.h 2>> /dev/null

--- a/src/scripts/ttmodule.py
+++ b/src/scripts/ttmodule.py
@@ -107,40 +107,46 @@ def main():
 The Three20 Module Script.
 Easily add Three20 modules to your projects.
 
-Modules may take the form <module-name>(:<module-target>)
+MODULES:
 
-module-target defaults to module-name if it is not specified
-module-name may be a path to a .pbxproj file.
+    Modules may take the form <module-name>(:<module-target>)
+    <module-target> defaults to <module-name> if it is not specified
+    <module-name> may be a path to a .pbxproj file.
 
-Examples:
-  Most common use case:
-  > %prog -p path/to/myApp/myApp.xcodeproj Three20
+EXAMPLES:
 
-  Print all dependencies for the Three20UI module
-  > %prog -d Three20UI
-
-  Print all dependencies for the Three20 module's Three20-Xcode3.2.5 target.
-  > %prog -d Three20:Three20-Xcode3.2.5
-
-  Add the Three20 project settings specifically to the Debug and Release configurations.
-  By default, all Three20 settings are added to all project configurations.
-  This includes adding the header search path and linker flags.
-  > %prog -p path/to/myApp.xcodeproj -c Debug -c Release
-
-  Add the extThree20XML module and all of its dependencies to the myApp project.
-  > %prog -p path/to/myApp.xcodeproj extThree20XML
-
-  Add a specific target of a module to a project.
-  > %prog -p path/to/myApp.xcodeproj extThree20JSON:extThree20JSON+SBJSON'''
+    Most common use case:
+    > %prog -p path/to/myApp/myApp.xcodeproj Three20
+    
+    Print all dependencies for the Three20UI module
+    > %prog -d Three20UI
+    
+    Print all dependencies for the Three20 module's Three20-Xcode3.2.5 target.
+    > %prog -d Three20:Three20-Xcode3.2.5
+    
+    Add the Three20 project settings specifically to the Debug and Release configurations.
+    By default, all Three20 settings are added to all project configurations.
+    This includes adding the header search path and linker flags.
+    > %prog -p path/to/myApp.xcodeproj -c Debug -c Release
+    
+    Add the extThree20XML module and all of its dependencies to the myApp project.
+    > %prog -p path/to/myApp.xcodeproj extThree20XML
+    
+    Add a specific target of a module to a project.
+    > %prog -p path/to/myApp.xcodeproj extThree20JSON:extThree20JSON+SBJSON'''
 	parser = OptionParser(usage = usage)
+	
 	parser.add_option("-d", "--dependencies", dest="print_dependencies",
 	                  help="Print dependencies for the given modules",
 	                  action="store_true")
+	
 	parser.add_option("-v", "--verbose", dest="verbose",
 	                  help="Display verbose output",
 	                  action="store_true")
+
 	parser.add_option("-p", "--project", dest="projects",
 	                  help="Add the given modules to this project", action="append")
+	
 	parser.add_option("-c", "--config", dest="configs",
 	                  help="Explicit configurations to add Three20 settings to (example: Debug). By default, ttmodule will add configuration settings to every configuration for the given target", action="append")
 

--- a/src/scripts/ttmodule.py
+++ b/src/scripts/ttmodule.py
@@ -125,8 +125,8 @@ EXAMPLES:
     Print all dependencies for the Three20UI module
     > %prog -d Three20UI
     
-    Print all dependencies for the Three20 module's Three20-Xcode3.2.5 target.
-    > %prog -d Three20:Three20-Xcode3.2.5
+    Print all dependencies for the extThree20JSON module's extThree20JSON+SBJSON target.
+    > %prog -d extThree20JSON:extThree20JSON+SBJSON
     
     Add the Three20 project settings specifically to the Debug and Release configurations.
     By default, all Three20 settings are added to all project configurations.

--- a/src/scripts/ttmodule.py
+++ b/src/scripts/ttmodule.py
@@ -23,6 +23,7 @@ limitations under the License.
 
 import logging
 import re
+import os
 import sys
 from optparse import OptionParser
 
@@ -118,6 +119,9 @@ EXAMPLES:
     Most common use case:
     > %prog -p path/to/myApp/myApp.xcodeproj Three20
     
+    For adding Xcode 4 support to an Xcode 3.2.# project:
+    > %prog -p path/to/myApp/myApp.xcodeproj Three20 --xcode-version=4
+    
     Print all dependencies for the Three20UI module
     > %prog -d Three20UI
     
@@ -146,6 +150,9 @@ EXAMPLES:
 
 	parser.add_option("-p", "--project", dest="projects",
 	                  help="Add the given modules to this project", action="append")
+
+	parser.add_option("--xcode-version", dest="xcode_version",
+	                  help="Set the xcode version you plan to open this project in. By default uses xcodebuild to determine your latest Xcode version.")
 	
 	parser.add_option("-c", "--config", dest="configs",
 	                  help="Explicit configurations to add Three20 settings to (example: Debug). By default, ttmodule will add configuration settings to every configuration for the given target", action="append")
@@ -167,8 +174,16 @@ EXAMPLES:
 
 	if options.projects is not None:
 		did_anything = True
+		
+		if not options.xcode_version:
+			f=os.popen("xcodebuild -version")
+			xcodebuild_version = f.readlines()[0]
+			match = re.search('Xcode ([a-zA-Z0-9.]+)', xcodebuild_version)
+			if match:
+				(options.xcode_version, ) = match.groups()
+		
 		for name in options.projects:
-			project = Pbxproj.get_pbxproj_by_name(name)
+			project = Pbxproj.get_pbxproj_by_name(name, xcode_version = options.xcode_version)
 			add_modules_to_project(args, project, options.configs)
 
 	if not did_anything:


### PR DESCRIPTION
This gives us full support for Xcode 4. The best part is that devs with Xcode 3.2.# who wish to upgrade to Xcode 4 just have to run the ttmodule script again!

For those who don't want to/can't use ttmodule, you simply need to add the following to your project's `HEADER_SEARCH_PATHS`:

```
"$(BUILT_PRODUCTS_DIR)/../three20"
"$(BUILT_PRODUCTS_DIR)/../../three20"
```

I'll put together a quick migration article on Three20.info outlining this for historical purposes.
