### PR TITLE
extThree20CSSStyle Additions

### DIFF
--- a/samples/Style/TTCSSStyleSheets/Classes/SampleCSSStyleSheet.h
+++ b/samples/Style/TTCSSStyleSheets/Classes/SampleCSSStyleSheet.h
@@ -14,10 +14,5 @@
 // limitations under the License.
 //
 
-// CSS Style
-#import "extThree20CSSStyle/extThree20CSSStyle.h"
-
-// Additions
-#import "extThree20CSSStyle/UILabelAdditions.h"
-#import "extThree20CSSStyle/TTTextStyleAdditions.h"
-#import "extThree20CSSStyle/TTShadowStyleAdditions.h"
+@interface SampleCSSStyleSheet : TTDefaultCSSStyleSheet {}
+@end

--- a/samples/Style/TTCSSStyleSheets/Classes/SampleCSSStyleSheet.m
+++ b/samples/Style/TTCSSStyleSheets/Classes/SampleCSSStyleSheet.m
@@ -14,10 +14,23 @@
 // limitations under the License.
 //
 
-// CSS Style
-#import "extThree20CSSStyle/extThree20CSSStyle.h"
+#import "SampleCSSStyleSheet.h"
 
-// Additions
-#import "extThree20CSSStyle/UILabelAdditions.h"
-#import "extThree20CSSStyle/TTTextStyleAdditions.h"
-#import "extThree20CSSStyle/TTShadowStyleAdditions.h"
+@implementation SampleCSSStyleSheet
+
+- (TTStyle *)h3:(UIControlState)state {
+  return
+  [TTSolidFillStyle styleWithColor:TTCSSSTATE(@"h3", backgroundColor, state) next:
+   [TTTextStyle styleWithCssSelector:@"h3" forState:state next:
+    nil]];
+}
+
+- (TTStyle *)h4:(UIControlState)state {
+  return
+  [TTSolidFillStyle styleWithColor:TTCSSSTATE(@"h4text", backgroundColor, state) next:
+   [TTShadowStyle styleWithCssSelector:@"h4shadow" forState:state next:
+    [TTTextStyle styleWithCssSelector:@"h4text" forState:state next:
+     nil]]];
+}
+
+@end

--- a/samples/Style/TTCSSStyleSheets/Classes/StyleSheetViewController.h
+++ b/samples/Style/TTCSSStyleSheets/Classes/StyleSheetViewController.h
@@ -16,8 +16,6 @@
 
 @interface StyleSheetViewController : TTViewController {
 @private
-  TTCSSStyleSheet*  _styleSheet;
-
   BOOL              _loadedSuccessfully;
 }
 

--- a/samples/Style/TTCSSStyleSheets/Classes/StyleSheetViewController.m
+++ b/samples/Style/TTCSSStyleSheets/Classes/StyleSheetViewController.m
@@ -25,22 +25,15 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
-  if (self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil]) {
-    _styleSheet = [[TTCSSStyleSheet alloc] init];
-
+  self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
+  if (self) {
+    TTDefaultCSSStyleSheet *_styleSheet = [[[TTDefaultCSSStyleSheet alloc] init] autorelease];
     _loadedSuccessfully = [_styleSheet
-                           loadFromFilename:TTPathForBundleResource(@"stylesheet.css")];
+                           addStyleSheetFromDisk:TTPathForBundleResource(@"stylesheet.css")];
+    [TTStyleSheet setGlobalStyleSheet:_styleSheet];
   }
 
   return self;
-}
-
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
-- (void)dealloc {
-  TT_RELEASE_SAFELY(_styleSheet);
-
-  [super dealloc];
 }
 
 
@@ -56,19 +49,14 @@
 
   self.title = @"Three20 CSS extension";
 
-  self.view.backgroundColor = [_styleSheet backgroundColorWithCssSelector: @"body"
-                                                                 forState: UIControlStateNormal];
-
+  self.view.backgroundColor = TTCSS(@"body", backgroundColor);
   UILabel* headerLabel = [[UILabel alloc] initWithFrame:CGRectZero];
   headerLabel.text = @"Header text";
-  headerLabel.font = [_styleSheet fontWithCssSelector:@"h1" forState:UIControlStateNormal];
-  headerLabel.textColor = [_styleSheet colorWithCssSelector:@"h1" forState:UIControlStateNormal];
-  headerLabel.backgroundColor = [_styleSheet backgroundColorWithCssSelector: @"h1"
-                                                                   forState: UIControlStateNormal];
-  headerLabel.shadowColor = [_styleSheet textShadowColorWithCssSelector: @"h1"
-                                                               forState: UIControlStateNormal];
-  headerLabel.shadowOffset = [_styleSheet textShadowOffsetWithCssSelector: @"h1"
-                                                                 forState: UIControlStateNormal];
+  headerLabel.font            = TTCSS(@"h1", font);
+  headerLabel.textColor       = TTCSS(@"h1", color);
+  headerLabel.backgroundColor = TTCSS(@"h1", backgroundColor);
+  headerLabel.shadowColor     = TTCSS(@"h1", shadowColor);
+  headerLabel.shadowOffset    = TTCSS(@"h1", shadowOffset);
   [headerLabel sizeToFit];
   [self.view addSubview:headerLabel];
   TT_RELEASE_SAFELY(headerLabel);

--- a/samples/Style/TTCSSStyleSheets/Classes/StyleSheetViewController.m
+++ b/samples/Style/TTCSSStyleSheets/Classes/StyleSheetViewController.m
@@ -48,8 +48,9 @@
   }
 
   self.title = @"Three20 CSS extension";
-
   self.view.backgroundColor = TTCSS(@"body", backgroundColor);
+
+  // Using helper macro
   UILabel* headerLabel = [[UILabel alloc] initWithFrame:CGRectZero];
   headerLabel.text = @"Header text";
   headerLabel.font            = TTCSS(@"h1", font);
@@ -59,7 +60,19 @@
   headerLabel.shadowOffset    = TTCSS(@"h1", shadowOffset);
   [headerLabel sizeToFit];
   [self.view addSubview:headerLabel];
+
+  // Using UILabel addition
+  UILabel* headerLabel2 = [[UILabel alloc] initWithFrame:CGRectZero];
+  headerLabel2.text = @"Header 2 text";
+  [headerLabel2 applyCssSelector:@"h2"];
+  [headerLabel2 sizeToFit];
+  CGRect frame = headerLabel2.frame;
+  frame.origin.y = headerLabel.frame.size.height;
+  headerLabel2.frame = frame;
+  [self.view addSubview:headerLabel2];
+
   TT_RELEASE_SAFELY(headerLabel);
+  TT_RELEASE_SAFELY(headerLabel2);
 }
 
 

--- a/samples/Style/TTCSSStyleSheets/Classes/StyleSheetViewController.m
+++ b/samples/Style/TTCSSStyleSheets/Classes/StyleSheetViewController.m
@@ -16,6 +16,8 @@
 
 #import "StyleSheetViewController.h"
 
+#import "SampleCSSStyleSheet.h"
+
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -27,7 +29,7 @@
 - (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
   self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
   if (self) {
-    TTDefaultCSSStyleSheet *_styleSheet = [[[TTDefaultCSSStyleSheet alloc] init] autorelease];
+    SampleCSSStyleSheet *_styleSheet = [[[SampleCSSStyleSheet alloc] init] autorelease];
     _loadedSuccessfully = [_styleSheet
                            addStyleSheetFromDisk:TTPathForBundleResource(@"stylesheet.css")];
     [TTStyleSheet setGlobalStyleSheet:_styleSheet];
@@ -66,10 +68,29 @@
   headerLabel2.text = @"Header 2 text";
   [headerLabel2 applyCssSelector:@"h2"];
   [headerLabel2 sizeToFit];
+  CGFloat top = headerLabel.frame.size.height;
   CGRect frame = headerLabel2.frame;
-  frame.origin.y = headerLabel.frame.size.height;
+  frame.origin.y = top;
   headerLabel2.frame = frame;
   [self.view addSubview:headerLabel2];
+
+  // Using TTTextStyle addition
+  TTButton* headerLabel3 = [TTButton buttonWithStyle:@"h3:" title:@"Header 3 text"];
+  [headerLabel3 sizeToFit];
+  top += headerLabel2.frame.size.height;
+  frame = headerLabel3.frame;
+  frame.origin.y = top;
+  headerLabel3.frame = frame;
+  [self.view addSubview:headerLabel3];
+
+  // Using TTTextStyle + TTShadowStyle addition
+  TTButton* headerLabel4 = [TTButton buttonWithStyle:@"h4:" title:@"Header 4 text"];
+  [headerLabel4 sizeToFit];
+  top += headerLabel2.frame.size.height;
+  frame = headerLabel4.frame;
+  frame.origin.y = top;
+  headerLabel4.frame = frame;
+  [self.view addSubview:headerLabel4];
 
   TT_RELEASE_SAFELY(headerLabel);
   TT_RELEASE_SAFELY(headerLabel2);

--- a/samples/Style/TTCSSStyleSheets/Headers/TTCSSStyleSheets_Prefix.pch
+++ b/samples/Style/TTCSSStyleSheets/Headers/TTCSSStyleSheets_Prefix.pch
@@ -6,6 +6,6 @@
   #import <Foundation/Foundation.h>
   #import <UIKit/UIKit.h>
   #import "Three20/Three20.h"
-  #import "extThree20CSSStyle/extThree20CSSStyle.h"
+  #import "extThree20CSSStyle/extThree20CSSStyle+Additions.h"
   #import "Atlas.h"
 #endif

--- a/samples/Style/TTCSSStyleSheets/Resources/stylesheet.css
+++ b/samples/Style/TTCSSStyleSheets/Resources/stylesheet.css
@@ -21,7 +21,15 @@ body {
 h1 {
   font-weight: bold;
   font-size: 50pt;
-  color: #666;
+  color: #FF6;
   background-color: transparent;
-  text-shadow: 1px 1px 1px #999; /* blur amount (3rd value) doesn't do anything */
+  text-shadow: 2px 2px 0px #F99;
+}
+
+h2 {
+  font-weight: bold;
+  font-size: 35pt;
+  color: white;
+  background-color: transparent;
+  text-shadow: 3px 3px 3px #99F;
 }

--- a/samples/Style/TTCSSStyleSheets/Resources/stylesheet.css
+++ b/samples/Style/TTCSSStyleSheets/Resources/stylesheet.css
@@ -15,7 +15,7 @@
  */
 
 body {
-  background-color: #111;
+  background-color: #114;
 }
 
 h1 {
@@ -27,9 +27,32 @@ h1 {
 }
 
 h2 {
-  font-weight: bold;
-  font-size: 35pt;
+  font-size: 45pt;
   color: white;
   background-color: transparent;
-  text-shadow: 3px 3px 3px #99F;
+  text-shadow: 0px 1px 3px #9BF;
 }
+
+h3, h3:hover {
+  font-size: 35pt;
+  font-weight: bold;
+  color: white;
+  background-color: transparent;
+  text-shadow: 3px -3px 3px #99F;
+}
+
+h3:hover {
+  color: #99F;
+  text-shadow: 3px 3px 3px white;
+}
+
+h4text, h4text:hover {
+  color: white;
+  font-size: 35pt;
+  background-color: transparent;
+}
+
+h4text:hover { color: gray; }
+
+h4shadow       { text-shadow: 3px 3px 4px rgba(0, 255, 0, .5); }
+h4shadow:hover { text-shadow: 0px 0px 4px green; }

--- a/samples/Style/TTCSSStyleSheets/TTCSSStyleSheets.xcodeproj/project.pbxproj
+++ b/samples/Style/TTCSSStyleSheets/TTCSSStyleSheets.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		6E850FAE11B176F10071A4FD /* Default.png in Resources */ = {isa = PBXBuildFile; fileRef = 6E850FAC11B176F10071A4FD /* Default.png */; };
 		6E850FAF11B176F10071A4FD /* Icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 6E850FAD11B176F10071A4FD /* Icon.png */; };
 		6E850FB811B1795F0071A4FD /* Atlas.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E850FB711B1795F0071A4FD /* Atlas.m */; };
+		90C3A1C1132BF66B00AC06A2 /* SampleCSSStyleSheet.m in Sources */ = {isa = PBXBuildFile; fileRef = 90C3A1C0132BF66B00AC06A2 /* SampleCSSStyleSheet.m */; };
 		EB383B6510BBF62B0000B2D2 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EB383B6410BBF62B0000B2D2 /* QuartzCore.framework */; };
 /* End PBXBuildFile section */
 
@@ -234,6 +235,8 @@
 		6E850FB711B1795F0071A4FD /* Atlas.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Atlas.m; sourceTree = "<group>"; };
 		6E8513D111B19B080071A4FD /* TTCSSStyleSheets_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TTCSSStyleSheets_Prefix.pch; path = Headers/TTCSSStyleSheets_Prefix.pch; sourceTree = "<group>"; };
 		6E8513D211B19B0E0071A4FD /* TTCSSStyleSheets-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "TTCSSStyleSheets-Info.plist"; sourceTree = "<group>"; };
+		90C3A1BF132BF66B00AC06A2 /* SampleCSSStyleSheet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SampleCSSStyleSheet.h; sourceTree = "<group>"; };
+		90C3A1C0132BF66B00AC06A2 /* SampleCSSStyleSheet.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SampleCSSStyleSheet.m; sourceTree = "<group>"; };
 		EB383B6410BBF62B0000B2D2 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -268,6 +271,8 @@
 				1D3623250D0F684500981E51 /* AppDelegate.m */,
 				6E850FB611B1795F0071A4FD /* Atlas.h */,
 				6E850FB711B1795F0071A4FD /* Atlas.m */,
+				90C3A1BF132BF66B00AC06A2 /* SampleCSSStyleSheet.h */,
+				90C3A1C0132BF66B00AC06A2 /* SampleCSSStyleSheet.m */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -680,6 +685,7 @@
 				1D3623260D0F684500981E51 /* AppDelegate.m in Sources */,
 				6E850FB811B1795F0071A4FD /* Atlas.m in Sources */,
 				6E036BF811B38F3C0025E8EE /* StyleSheetViewController.m in Sources */,
+				90C3A1C1132BF66B00AC06A2 /* SampleCSSStyleSheet.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/src/extThree20CSSStyle/Headers/TTCSSGlobalStyle.h
+++ b/src/extThree20CSSStyle/Headers/TTCSSGlobalStyle.h
@@ -1,0 +1,42 @@
+//
+// Copyright 2009-2011 Facebook
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// CSS Style helpers
+
+#define TTCSSSTYLESHEET ([[TTDefaultCSSStyleSheet globalCSSStyleSheet] styleSheet])
+
+#define TTCSS_color(_SELECTOR, _STATE) \
+([TTCSSSTYLESHEET colorWithCssSelector:_SELECTOR forState:_STATE])
+
+#define TTCSS_backgroundColor(_SELECTOR, _STATE) \
+([TTCSSSTYLESHEET backgroundColorWithCssSelector:_SELECTOR forState:_STATE])
+
+#define TTCSS_font(_SELECTOR, _STATE) \
+([TTCSSSTYLESHEET fontWithCssSelector:_SELECTOR forState:_STATE])
+
+#define TTCSS_shadowColor(_SELECTOR, _STATE) \
+([TTCSSSTYLESHEET textShadowColorWithCssSelector:_SELECTOR forState:_STATE])
+
+#define TTCSS_shadowOffset(_SELECTOR, _STATE) \
+([TTCSSSTYLESHEET textShadowOffsetWithCssSelector:_SELECTOR forState:_STATE])
+
+// _VARNAME must be one of: color, backgroundColor, font, shadowColor, shadowOffset
+#define TTCSSSTATE(_SELECTOR, _VARNAME, _STATE) \
+TTCSS_##_VARNAME(_SELECTOR, _STATE)
+
+#define TTCSS(_SELECTOR, _VARNAME) \
+TTCSSSTATE(_SELECTOR, _VARNAME, UIControlStateNormal)

--- a/src/extThree20CSSStyle/Headers/TTCSSGlobalStyle.h
+++ b/src/extThree20CSSStyle/Headers/TTCSSGlobalStyle.h
@@ -34,7 +34,10 @@
 #define TTCSS_shadowOffset(_SELECTOR, _STATE) \
 ([TTCSSSTYLESHEET textShadowOffsetWithCssSelector:_SELECTOR forState:_STATE])
 
-// _VARNAME must be one of: color, backgroundColor, font, shadowColor, shadowOffset
+#define TTCSS_shadowRadius(_SELECTOR, _STATE) \
+([TTCSSSTYLESHEET textShadowRadiusWithCssSelector:_SELECTOR forState:_STATE])
+
+// _VARNAME must be one of: color, backgroundColor, font, shadowColor, shadowOffset, shadowRadius
 #define TTCSSSTATE(_SELECTOR, _VARNAME, _STATE) \
 TTCSS_##_VARNAME(_SELECTOR, _STATE)
 

--- a/src/extThree20CSSStyle/Headers/TTCSSStyleSheet.h
+++ b/src/extThree20CSSStyle/Headers/TTCSSStyleSheet.h
@@ -75,6 +75,11 @@
  */
 - (CGSize)textShadowOffsetWithCssSelector:(NSString*)selector forState:(UIControlState)state;
 
+/**
+ * Get text shadow radius from a specific rule set.
+ */
+- (CGFloat)textShadowRadiusWithCssSelector:(NSString*)selector forState:(UIControlState)state;
+
 
 /**
  * Release all cached data.

--- a/src/extThree20CSSStyle/Headers/TTShadowStyleAdditions.h
+++ b/src/extThree20CSSStyle/Headers/TTShadowStyleAdditions.h
@@ -14,10 +14,15 @@
 // limitations under the License.
 //
 
-// CSS Style
-#import "extThree20CSSStyle/extThree20CSSStyle.h"
+#import "Three20Style/TTShadowStyle.h"
 
-// Additions
-#import "extThree20CSSStyle/UILabelAdditions.h"
-#import "extThree20CSSStyle/TTTextStyleAdditions.h"
-#import "extThree20CSSStyle/TTShadowStyleAdditions.h"
+@interface TTShadowStyle (TTCSSCategory)
+
++ (TTShadowStyle*)styleWithCssSelector:(NSString*)selector
+                              forState:(UIControlState)state
+                                  next:(TTStyle*)next;
+
++ (TTShadowStyle*)styleWithCssSelector:(NSString*)selector
+                                  next:(TTStyle*)next;
+
+@end

--- a/src/extThree20CSSStyle/Headers/TTTextStyleAdditions.h
+++ b/src/extThree20CSSStyle/Headers/TTTextStyleAdditions.h
@@ -1,0 +1,55 @@
+//
+// Copyright 2009-2011 Facebook
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "Three20Style/TTTextStyle.h"
+
+@interface TTTextStyle (TTCSSCategory)
+
++ (TTTextStyle*)styleWithCssSelector:(NSString*)selector
+                                next:(TTStyle*)next;
+
++ (TTTextStyle*)styleWithCssSelector:(NSString*)selector
+                     minimumFontSize:(CGFloat)minimumFontSize
+                                next:(TTStyle*)next;
+
++ (TTTextStyle*)styleWithCssSelector:(NSString*)selector
+                     minimumFontSize:(CGFloat)minimumFontSize
+                       textAlignment:(UITextAlignment)textAlignment
+                   verticalAlignment:(UIControlContentVerticalAlignment)verticalAlignment
+                       lineBreakMode:(UILineBreakMode)lineBreakMode
+                       numberOfLines:(NSInteger)numberOfLines
+                                next:(TTStyle*)next;
+
+
++ (TTTextStyle*)styleWithCssSelector:(NSString*)selector
+                            forState:(UIControlState)state
+                                next:(TTStyle*)next;
+
++ (TTTextStyle*)styleWithCssSelector:(NSString*)selector
+                            forState:(UIControlState)state
+                     minimumFontSize:(CGFloat)minimumFontSize
+                                next:(TTStyle*)next;
+
++ (TTTextStyle*)styleWithCssSelector:(NSString*)selector
+                            forState:(UIControlState)state
+                     minimumFontSize:(CGFloat)minimumFontSize
+                       textAlignment:(UITextAlignment)textAlignment
+                   verticalAlignment:(UIControlContentVerticalAlignment)verticalAlignment
+                       lineBreakMode:(UILineBreakMode)lineBreakMode
+                       numberOfLines:(NSInteger)numberOfLines
+                                next:(TTStyle*)next;
+
+@end

--- a/src/extThree20CSSStyle/Headers/UILabelAdditions.h
+++ b/src/extThree20CSSStyle/Headers/UILabelAdditions.h
@@ -1,0 +1,27 @@
+//
+// Copyright 2009-2011 Facebook
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+@interface UILabel (TTCSSCategory)
+
+/**
+ * Set a css stylesheet selector, will set font, colors and shadow.
+ */
+- (void)applyCssSelector:(NSString *)selector;
+
+@end

--- a/src/extThree20CSSStyle/Headers/extThree20CSSStyle+Additions.h
+++ b/src/extThree20CSSStyle/Headers/extThree20CSSStyle+Additions.h
@@ -1,0 +1,21 @@
+//
+// Copyright 2009-2011 Facebook
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// CSS Style
+#import "extThree20CSSStyle/extThree20CSSStyle.h"
+
+// Additions
+#import "extThree20CSSStyle/UILabelAdditions.h"

--- a/src/extThree20CSSStyle/Headers/extThree20CSSStyle.h
+++ b/src/extThree20CSSStyle/Headers/extThree20CSSStyle.h
@@ -18,5 +18,6 @@
 #import "extThree20CSSStyle/TTCSSParser.h"
 
 // CSS Stylesheet
+#import "extThree20CSSStyle/TTCSSGlobalStyle.h"
 #import "extThree20CSSStyle/TTCSSStyleSheet.h"
 #import "extThree20CSSStyle/TTDefaultCSSStyleSheet.h"

--- a/src/extThree20CSSStyle/README.mdown
+++ b/src/extThree20CSSStyle/README.mdown
@@ -92,11 +92,6 @@ Known Limitations
 Font-size is always interpreted in points, regardless of what you specify. This is due to
 the tricky nature of varying DPI on the various iPhone OS devices.
 
-### Text Shadows
-
-The "blur" property is always interpreted as "0". This is due to the technical limitations
-of specifying blur for text shadows for UILabels.
-
 
 Supported CSS Properties and Values
 -----------------------------------
@@ -139,14 +134,12 @@ Fonts are defined with a set of properties that collectively create the final UI
 
 ### Text Shadow
 
-    text-shadow:      <number>px <number>px <ignored> <color>
+    text-shadow:      <number>px <number>px <number>px <color>
                       textShadowColorWithCssSelector
                       textShadowOffsetWithCssSelector
+                      textShadowRadiusWithCssSelector
 
 The `text-shadow` property is defined in one chunk, but read using two distinct methods.
-
-The third parameter is ignored. See "Text Shadows" in the `Known Limitations` section for
-the technical reasons.
 
 
 Examples

--- a/src/extThree20CSSStyle/Sources/TTCSSStyleSheet.m
+++ b/src/extThree20CSSStyle/Sources/TTCSSStyleSheet.m
@@ -439,6 +439,10 @@ NSString* kKeyTextShadowColor   = @"color";
     // The given selector actually exists in the CSS.
     if (nil != ruleSet) {
       NSArray* values = [ruleSet objectForKey:kCssPropertyTextShadow];
+
+      // Safety check
+      if (nil == values) return nil;
+
       // Anything more or less is unsupported, and therefore this property is ignored
       // according to the W3C guidelines.
       TTDASSERT([values count] >= 4);
@@ -476,7 +480,7 @@ NSString* kKeyTextShadowColor   = @"color";
 
   NSDictionary* textShadow = [self textShadowWithCssSelector: selector
                                                     forState: state];
-  return [textShadow objectForKey:kKeyTextShadowColor];
+  return nil != textShadow ? [textShadow objectForKey:kKeyTextShadowColor] : nil;
 }
 
 
@@ -486,8 +490,10 @@ NSString* kKeyTextShadowColor   = @"color";
 
   NSDictionary* textShadow = [self textShadowWithCssSelector: selector
                                                     forState: state];
-  return CGSizeMake([[textShadow objectForKey:kKeyTextShadowHOffset] floatValue],
-                    [[textShadow objectForKey:kKeyTextShadowVOffset] floatValue]);
+  return nil != textShadow ?
+  CGSizeMake([[textShadow objectForKey:kKeyTextShadowHOffset] floatValue],
+             [[textShadow objectForKey:kKeyTextShadowVOffset] floatValue]) :
+  CGSizeZero;
 }
 
 
@@ -497,7 +503,7 @@ NSString* kKeyTextShadowColor   = @"color";
 
   NSDictionary* textShadow = [self textShadowWithCssSelector: selector
                                                     forState: state];
-  return [[textShadow objectForKey:kKeyTextShadowBlur] floatValue];
+  return nil != textShadow ? [[textShadow objectForKey:kKeyTextShadowBlur] floatValue] : 0;
 }
 
 

--- a/src/extThree20CSSStyle/Sources/TTCSSStyleSheet.m
+++ b/src/extThree20CSSStyle/Sources/TTCSSStyleSheet.m
@@ -492,6 +492,16 @@ NSString* kKeyTextShadowColor   = @"color";
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
+- (CGFloat)textShadowRadiusWithCssSelector:(NSString*)selector forState:(UIControlState)state {
+  selector = [self selector:selector forState:state];
+
+  NSDictionary* textShadow = [self textShadowWithCssSelector: selector
+                                                    forState: state];
+  return [[textShadow objectForKey:kKeyTextShadowBlur] floatValue];
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark -
 #pragma mark Utilities

--- a/src/extThree20CSSStyle/Sources/TTDefaultCSSStyleSheet.h
+++ b/src/extThree20CSSStyle/Sources/TTDefaultCSSStyleSheet.h
@@ -18,9 +18,6 @@
 
 @class TTCSSStyleSheet;
 
-#define TTCSSBGCOLOR(selector)  [[TTDefaultCSSStyleSheet globalCSSStyleSheet] \
-                                  backgroundColorForCSSSelector:selector]
-
 @interface TTDefaultCSSStyleSheet : TTDefaultStyleSheet {
 @private
   TTCSSStyleSheet* _styleSheet;
@@ -29,8 +26,6 @@
 @property (nonatomic, readonly) TTCSSStyleSheet* styleSheet;
 
 - (BOOL)addStyleSheetFromDisk:(NSString*)filename;
-
-- (UIColor*)backgroundColorForCSSSelector:(NSString*)cssSelector;
 
 + (TTDefaultCSSStyleSheet*)globalCSSStyleSheet;
 

--- a/src/extThree20CSSStyle/Sources/TTDefaultCSSStyleSheet.m
+++ b/src/extThree20CSSStyle/Sources/TTDefaultCSSStyleSheet.m
@@ -116,13 +116,6 @@ NSString* kDefaultCSSPath = @"extThree20CSSStyle.bundle/stylesheets/default.css"
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-- (UIColor*)backgroundColorForCSSSelector:(NSString*)cssSelector {
-  return [_styleSheet backgroundColorWithCssSelector: cssSelector
-                                            forState: UIControlStateNormal];
-}
-
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
 + (TTDefaultCSSStyleSheet*)globalCSSStyleSheet {
   TTDASSERT([[TTStyleSheet globalStyleSheet] isKindOfClass:[TTDefaultStyleSheet class]]);
   return (TTDefaultCSSStyleSheet*)[TTStyleSheet globalStyleSheet];

--- a/src/extThree20CSSStyle/Sources/TTShadowStyleAdditions.m
+++ b/src/extThree20CSSStyle/Sources/TTShadowStyleAdditions.m
@@ -1,0 +1,63 @@
+//
+// Copyright 2009-2011 Facebook
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "extThree20CSSStyle/TTShadowStyleAdditions.h"
+
+#import "extThree20CSSStyle/TTCSSGlobalStyle.h"
+#import "extThree20CSSStyle/TTCSSStyleSheet.h"
+#import "extThree20CSSStyle/TTDefaultCSSStyleSheet.h"
+
+// Core
+#import "Three20Core/TTCorePreprocessorMacros.h"
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////
+/**
+ * Additions.
+ */
+TT_FIX_CATEGORY_BUG(TTCSSShadowStyleAdditions)
+
+@implementation TTShadowStyle (TTCSSCategory)
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark -
+#pragma mark Class public
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
++ (TTShadowStyle*)styleWithCssSelector:(NSString*)selector
+                              forState:(UIControlState)state
+                                  next:(TTStyle*)next {
+  TTShadowStyle* style = [[[self alloc] initWithNext:next] autorelease];
+  style.color  = TTCSSSTATE(selector, shadowColor,  state);
+  style.blur   = TTCSSSTATE(selector, shadowRadius, state);
+  style.offset = TTCSSSTATE(selector, shadowOffset, state);
+  return style;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
++ (TTShadowStyle*)styleWithCssSelector:(NSString*)selector
+                                  next:(TTStyle*)next {
+  return [self styleWithCssSelector:selector
+                           forState:UIControlStateNormal next:next];
+}
+
+
+@end

--- a/src/extThree20CSSStyle/Sources/TTTextStyleAdditions.m
+++ b/src/extThree20CSSStyle/Sources/TTTextStyleAdditions.m
@@ -1,0 +1,130 @@
+//
+// Copyright 2009-2011 Facebook
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "extThree20CSSStyle/TTTextStyleAdditions.h"
+
+#import "extThree20CSSStyle/TTCSSGlobalStyle.h"
+#import "extThree20CSSStyle/TTCSSStyleSheet.h"
+#import "extThree20CSSStyle/TTDefaultCSSStyleSheet.h"
+
+// Core
+#import "Three20Core/TTCorePreprocessorMacros.h"
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////
+/**
+ * Additions.
+ */
+TT_FIX_CATEGORY_BUG(TTCSSTextStyleAdditions)
+
+@implementation TTTextStyle (TTCSSCategory)
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark -
+#pragma mark Class public
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
++ (TTTextStyle*)styleWithCssSelector:(NSString*)selector
+                            forState:(UIControlState)state
+                                next:(TTStyle*)next {
+  TTTextStyle* style = [[[self alloc] initWithNext:next] autorelease];
+  UIFont  *font         = TTCSSSTATE(selector, font, state);
+  UIColor *color        = TTCSSSTATE(selector, color, state);
+  UIColor *shadowColor  = TTCSSSTATE(selector, shadowColor, state);
+  CGSize   shadowOffset = TTCSSSTATE(selector, shadowOffset, state);
+
+  if (font)  style.font  = font;
+  if (color) style.color = color;
+  if (shadowColor) {
+    style.shadowColor  = shadowColor;
+    style.shadowOffset = shadowOffset;
+  }
+  return style;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
++ (TTTextStyle*)styleWithCssSelector:(NSString*)selector
+                            forState:(UIControlState)state
+                     minimumFontSize:(CGFloat)minimumFontSize
+                                next:(TTStyle*)next {
+  TTTextStyle* style = [self styleWithCssSelector:selector forState:state next:next];
+  style.minimumFontSize = minimumFontSize;
+  return style;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
++ (TTTextStyle*)styleWithCssSelector:(NSString*)selector
+                            forState:(UIControlState)state
+                     minimumFontSize:(CGFloat)minimumFontSize
+                       textAlignment:(UITextAlignment)textAlignment
+                   verticalAlignment:(UIControlContentVerticalAlignment)verticalAlignment
+                       lineBreakMode:(UILineBreakMode)lineBreakMode
+                       numberOfLines:(NSInteger)numberOfLines
+                                next:(TTStyle*)next {
+  TTTextStyle* style = [self styleWithCssSelector:selector forState:state next:next];
+  style.minimumFontSize = minimumFontSize;
+  style.textAlignment = textAlignment;
+  style.verticalAlignment = verticalAlignment;
+  style.lineBreakMode = lineBreakMode;
+  style.numberOfLines = numberOfLines;
+  return style;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
++ (TTTextStyle*)styleWithCssSelector:(NSString*)selector next:(TTStyle*)next {
+  return [self styleWithCssSelector:selector
+                           forState:UIControlStateNormal
+                               next:next];
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
++ (TTTextStyle*)styleWithCssSelector:(NSString*)selector
+                     minimumFontSize:(CGFloat)minimumFontSize
+                                next:(TTStyle*)next {
+  return [self styleWithCssSelector:selector
+                           forState:UIControlStateNormal
+                    minimumFontSize:minimumFontSize
+                               next:next];
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
++ (TTTextStyle*)styleWithCssSelector:(NSString*)selector
+                     minimumFontSize:(CGFloat)minimumFontSize
+                       textAlignment:(UITextAlignment)textAlignment
+                   verticalAlignment:(UIControlContentVerticalAlignment)verticalAlignment
+                       lineBreakMode:(UILineBreakMode)lineBreakMode
+                       numberOfLines:(NSInteger)numberOfLines
+                                next:(TTStyle*)next {
+  return [self styleWithCssSelector:selector
+                           forState:UIControlStateNormal
+                    minimumFontSize:minimumFontSize
+                      textAlignment:textAlignment
+                  verticalAlignment:verticalAlignment
+                      lineBreakMode:lineBreakMode
+                      numberOfLines:numberOfLines
+                               next:next];
+}
+
+@end

--- a/src/extThree20CSSStyle/Sources/UILabelAdditions.m
+++ b/src/extThree20CSSStyle/Sources/UILabelAdditions.m
@@ -1,0 +1,73 @@
+//
+// Copyright 2009-2011 Facebook
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "extThree20CSSStyle/UILabelAdditions.h"
+
+#import "extThree20CSSStyle/TTCSSGlobalStyle.h"
+#import "extThree20CSSStyle/TTCSSStyleSheet.h"
+#import "extThree20CSSStyle/TTDefaultCSSStyleSheet.h"
+
+// Core
+#import "Three20Core/TTCorePreprocessorMacros.h"
+
+#ifdef __IPHONE_3_2
+#import <QuartzCore/QuartzCore.h>
+#endif
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////
+/**
+ * Additions.
+ */
+TT_FIX_CATEGORY_BUG(TTCSSLabelAdditions)
+
+@implementation UILabel (TTCSSCategory)
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)applyCssSelector:(NSString *)selector {
+  UIFont  *font            = TTCSS(selector, font);
+  UIColor *color           = TTCSS(selector, color);
+  UIColor *backgroundColor = TTCSS(selector, backgroundColor);
+
+  if (font)            self.font            = font;
+  if (color)           self.textColor       = color;
+  if (backgroundColor) self.backgroundColor = backgroundColor;
+
+  UIColor *shadowColor     = TTCSS(selector, shadowColor);
+  CGSize   shadowOffset    = TTCSS(selector, shadowOffset);
+  if (shadowColor) {
+#ifdef __IPHONE_3_2
+    CGFloat shadowRadius = TTCSS(selector, shadowRadius);
+    if (shadowRadius) {
+      self.layer.shadowOpacity = 1.0;
+      self.layer.shadowColor   = shadowColor.CGColor;
+      self.layer.shadowOffset  = shadowOffset;
+      self.layer.shadowRadius  = shadowRadius;
+      self.layer.masksToBounds = NO;
+    }
+    else {
+      self.shadowColor  = shadowColor;
+      self.shadowOffset = shadowOffset;
+    }
+#else
+    self.shadowColor  = shadowColor;
+    self.shadowOffset = shadowOffset;
+#endif
+  }
+}
+
+@end

--- a/src/extThree20CSSStyle/extThree20CSSStyle.xcodeproj/project.pbxproj
+++ b/src/extThree20CSSStyle/extThree20CSSStyle.xcodeproj/project.pbxproj
@@ -46,6 +46,10 @@
 		90C3A1B5132BE3EB00AC06A2 /* UILabelAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 90C3A1B3132BE3EB00AC06A2 /* UILabelAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		90C3A1B6132BE3EB00AC06A2 /* UILabelAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 90C3A1B4132BE3EB00AC06A2 /* UILabelAdditions.m */; };
 		90C3A1B8132BE40100AC06A2 /* extThree20CSSStyle+Additions.h in Headers */ = {isa = PBXBuildFile; fileRef = 90C3A1B7132BE40100AC06A2 /* extThree20CSSStyle+Additions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		90C3A1BD132BF2D100AC06A2 /* TTTextStyleAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 90C3A1BB132BF2D100AC06A2 /* TTTextStyleAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		90C3A1BE132BF2D100AC06A2 /* TTTextStyleAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 90C3A1BC132BF2D100AC06A2 /* TTTextStyleAdditions.m */; };
+		90C3A1C4132BFDFF00AC06A2 /* TTShadowStyleAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 90C3A1C2132BFDFE00AC06A2 /* TTShadowStyleAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		90C3A1C5132BFDFF00AC06A2 /* TTShadowStyleAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 90C3A1C3132BFDFF00AC06A2 /* TTShadowStyleAdditions.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -165,6 +169,10 @@
 		90C3A1B4132BE3EB00AC06A2 /* UILabelAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = UILabelAdditions.m; path = Sources/UILabelAdditions.m; sourceTree = "<group>"; };
 		90C3A1B7132BE40100AC06A2 /* extThree20CSSStyle+Additions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "extThree20CSSStyle+Additions.h"; path = "Headers/extThree20CSSStyle+Additions.h"; sourceTree = "<group>"; };
 		90C3A1B9132BEB7100AC06A2 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		90C3A1BB132BF2D100AC06A2 /* TTTextStyleAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TTTextStyleAdditions.h; path = Headers/TTTextStyleAdditions.h; sourceTree = "<group>"; };
+		90C3A1BC132BF2D100AC06A2 /* TTTextStyleAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TTTextStyleAdditions.m; path = Sources/TTTextStyleAdditions.m; sourceTree = "<group>"; };
+		90C3A1C2132BFDFE00AC06A2 /* TTShadowStyleAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TTShadowStyleAdditions.h; path = Headers/TTShadowStyleAdditions.h; sourceTree = "<group>"; };
+		90C3A1C3132BFDFF00AC06A2 /* TTShadowStyleAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TTShadowStyleAdditions.m; path = Sources/TTShadowStyleAdditions.m; sourceTree = "<group>"; };
 		BEF31F3A0F352DF5000DE5D2 /* libextThree20CSSStyle.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libextThree20CSSStyle.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		EB9E6C6210B6A8F800DE563C /* extCSSStyleUnitTests.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = extCSSStyleUnitTests.octest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -380,6 +388,10 @@
 			children = (
 				90C3A1B3132BE3EB00AC06A2 /* UILabelAdditions.h */,
 				90C3A1B4132BE3EB00AC06A2 /* UILabelAdditions.m */,
+				90C3A1BB132BF2D100AC06A2 /* TTTextStyleAdditions.h */,
+				90C3A1BC132BF2D100AC06A2 /* TTTextStyleAdditions.m */,
+				90C3A1C2132BFDFE00AC06A2 /* TTShadowStyleAdditions.h */,
+				90C3A1C3132BFDFF00AC06A2 /* TTShadowStyleAdditions.m */,
 			);
 			name = Additions;
 			sourceTree = "<group>";
@@ -400,6 +412,8 @@
 				6E036D1911B487CF0025E8EE /* TTDefaultCSSStyleSheet.h in Headers */,
 				66E722D3129392EB007134B0 /* TTExtensionLoader.h in Headers */,
 				90C3A1B5132BE3EB00AC06A2 /* UILabelAdditions.h in Headers */,
+				90C3A1BD132BF2D100AC06A2 /* TTTextStyleAdditions.h in Headers */,
+				90C3A1C4132BFDFF00AC06A2 /* TTShadowStyleAdditions.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -617,6 +631,8 @@
 				6E036D1A11B487CF0025E8EE /* TTDefaultCSSStyleSheet.m in Sources */,
 				66E722D0129392DD007134B0 /* TTExtensionLoader.m in Sources */,
 				90C3A1B6132BE3EB00AC06A2 /* UILabelAdditions.m in Sources */,
+				90C3A1BE132BF2D100AC06A2 /* TTTextStyleAdditions.m in Sources */,
+				90C3A1C5132BFDFF00AC06A2 /* TTShadowStyleAdditions.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/src/extThree20CSSStyle/extThree20CSSStyle.xcodeproj/project.pbxproj
+++ b/src/extThree20CSSStyle/extThree20CSSStyle.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		6E85154011B2E8660071A4FD /* TTCSSParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E85145111B1B5200071A4FD /* TTCSSParser.m */; };
 		6EAE4E5611B2F0A7001073B4 /* testcase.css in Resources */ = {isa = PBXBuildFile; fileRef = 6EAE4E5511B2F0A7001073B4 /* testcase.css */; };
 		6EB460DA1183D8CB00685649 /* libextThree20CSSStyle.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BEF31F3A0F352DF5000DE5D2 /* libextThree20CSSStyle.a */; };
+		90C3A115132B9BE100AC06A2 /* TTCSSGlobalStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 90C3A114132B9BE100AC06A2 /* TTCSSGlobalStyle.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -156,6 +157,7 @@
 		6EAE4E5511B2F0A7001073B4 /* testcase.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; name = testcase.css; path = UnitTests/Resources/CSS/testcase.css; sourceTree = "<group>"; };
 		6EB460921183D16000685649 /* UnitTests-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "UnitTests-Info.plist"; path = "UnitTests/Resources/PropertyLists/UnitTests-Info.plist"; sourceTree = "<group>"; };
 		6EB460A61183D2AC00685649 /* UnitTests.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = UnitTests.xcconfig; path = Configurations/UnitTests.xcconfig; sourceTree = "<group>"; };
+		90C3A114132B9BE100AC06A2 /* TTCSSGlobalStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TTCSSGlobalStyle.h; path = Headers/TTCSSGlobalStyle.h; sourceTree = "<group>"; };
 		BEF31F3A0F352DF5000DE5D2 /* libextThree20CSSStyle.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libextThree20CSSStyle.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		EB9E6C6210B6A8F800DE563C /* extCSSStyleUnitTests.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = extCSSStyleUnitTests.octest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -318,6 +320,7 @@
 		6EB4609C1183D1E000685649 /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				90C3A10F132B9B5000AC06A2 /* Global */,
 				6E036A2A11B364AF0025E8EE /* CSS Parser */,
 				6E036A2B11B364B60025E8EE /* CSS Stylesheet */,
 			);
@@ -354,6 +357,14 @@
 			name = Configurations;
 			sourceTree = "<group>";
 		};
+		90C3A10F132B9B5000AC06A2 /* Global */ = {
+			isa = PBXGroup;
+			children = (
+				90C3A114132B9BE100AC06A2 /* TTCSSGlobalStyle.h */,
+			);
+			name = Global;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -362,6 +373,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6E3C3470118806590079637E /* extThree20CSSStyle.h in Headers */,
+				90C3A115132B9BE100AC06A2 /* TTCSSGlobalStyle.h in Headers */,
 				6E85145411B1B5390071A4FD /* TTCSSParser.h in Headers */,
 				6E8514ED11B2E3F30071A4FD /* CssTokens.h in Headers */,
 				6E036A3211B364DF0025E8EE /* TTCSSStyleSheet.h in Headers */,

--- a/src/extThree20CSSStyle/extThree20CSSStyle.xcodeproj/project.pbxproj
+++ b/src/extThree20CSSStyle/extThree20CSSStyle.xcodeproj/project.pbxproj
@@ -43,6 +43,9 @@
 		6EAE4E5611B2F0A7001073B4 /* testcase.css in Resources */ = {isa = PBXBuildFile; fileRef = 6EAE4E5511B2F0A7001073B4 /* testcase.css */; };
 		6EB460DA1183D8CB00685649 /* libextThree20CSSStyle.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BEF31F3A0F352DF5000DE5D2 /* libextThree20CSSStyle.a */; };
 		90C3A115132B9BE100AC06A2 /* TTCSSGlobalStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 90C3A114132B9BE100AC06A2 /* TTCSSGlobalStyle.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		90C3A1B5132BE3EB00AC06A2 /* UILabelAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 90C3A1B3132BE3EB00AC06A2 /* UILabelAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		90C3A1B6132BE3EB00AC06A2 /* UILabelAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 90C3A1B4132BE3EB00AC06A2 /* UILabelAdditions.m */; };
+		90C3A1B8132BE40100AC06A2 /* extThree20CSSStyle+Additions.h in Headers */ = {isa = PBXBuildFile; fileRef = 90C3A1B7132BE40100AC06A2 /* extThree20CSSStyle+Additions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -158,6 +161,10 @@
 		6EB460921183D16000685649 /* UnitTests-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "UnitTests-Info.plist"; path = "UnitTests/Resources/PropertyLists/UnitTests-Info.plist"; sourceTree = "<group>"; };
 		6EB460A61183D2AC00685649 /* UnitTests.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = UnitTests.xcconfig; path = Configurations/UnitTests.xcconfig; sourceTree = "<group>"; };
 		90C3A114132B9BE100AC06A2 /* TTCSSGlobalStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TTCSSGlobalStyle.h; path = Headers/TTCSSGlobalStyle.h; sourceTree = "<group>"; };
+		90C3A1B3132BE3EB00AC06A2 /* UILabelAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UILabelAdditions.h; path = Headers/UILabelAdditions.h; sourceTree = "<group>"; };
+		90C3A1B4132BE3EB00AC06A2 /* UILabelAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = UILabelAdditions.m; path = Sources/UILabelAdditions.m; sourceTree = "<group>"; };
+		90C3A1B7132BE40100AC06A2 /* extThree20CSSStyle+Additions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "extThree20CSSStyle+Additions.h"; path = "Headers/extThree20CSSStyle+Additions.h"; sourceTree = "<group>"; };
+		90C3A1B9132BEB7100AC06A2 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		BEF31F3A0F352DF5000DE5D2 /* libextThree20CSSStyle.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libextThree20CSSStyle.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		EB9E6C6210B6A8F800DE563C /* extCSSStyleUnitTests.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = extCSSStyleUnitTests.octest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -199,6 +206,7 @@
 			children = (
 				6E036B3611B38A420025E8EE /* README.mdown */,
 				6E646518118805EB00F08CB1 /* extThree20CSSStyle.h */,
+				90C3A1B7132BE40100AC06A2 /* extThree20CSSStyle+Additions.h */,
 				66313D671267BFCF00C09C9F /* extThree20CSSStyle_Prefix.pch */,
 				66E722D1129392EB007134B0 /* TTExtensionLoader.h */,
 				66E722CC129392DD007134B0 /* TTExtensionLoader.m */,
@@ -274,6 +282,7 @@
 				6E85154F11B2E93E0071A4FD /* Foundation.framework */,
 				6E85155511B2E94E0071A4FD /* CoreGraphics.framework */,
 				6E036B6111B38D1B0025E8EE /* UIKit.framework */,
+				90C3A1B9132BEB7100AC06A2 /* QuartzCore.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -321,6 +330,7 @@
 			isa = PBXGroup;
 			children = (
 				90C3A10F132B9B5000AC06A2 /* Global */,
+				90C3A1AF132BE3C800AC06A2 /* Additions */,
 				6E036A2A11B364AF0025E8EE /* CSS Parser */,
 				6E036A2B11B364B60025E8EE /* CSS Stylesheet */,
 			);
@@ -365,6 +375,15 @@
 			name = Global;
 			sourceTree = "<group>";
 		};
+		90C3A1AF132BE3C800AC06A2 /* Additions */ = {
+			isa = PBXGroup;
+			children = (
+				90C3A1B3132BE3EB00AC06A2 /* UILabelAdditions.h */,
+				90C3A1B4132BE3EB00AC06A2 /* UILabelAdditions.m */,
+			);
+			name = Additions;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -373,12 +392,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				6E3C3470118806590079637E /* extThree20CSSStyle.h in Headers */,
+				90C3A1B8132BE40100AC06A2 /* extThree20CSSStyle+Additions.h in Headers */,
 				90C3A115132B9BE100AC06A2 /* TTCSSGlobalStyle.h in Headers */,
 				6E85145411B1B5390071A4FD /* TTCSSParser.h in Headers */,
 				6E8514ED11B2E3F30071A4FD /* CssTokens.h in Headers */,
 				6E036A3211B364DF0025E8EE /* TTCSSStyleSheet.h in Headers */,
 				6E036D1911B487CF0025E8EE /* TTDefaultCSSStyleSheet.h in Headers */,
 				66E722D3129392EB007134B0 /* TTExtensionLoader.h in Headers */,
+				90C3A1B5132BE3EB00AC06A2 /* UILabelAdditions.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -595,6 +616,7 @@
 				6E036A3011B364CC0025E8EE /* TTCSSStyleSheet.m in Sources */,
 				6E036D1A11B487CF0025E8EE /* TTDefaultCSSStyleSheet.m in Sources */,
 				66E722D0129392DD007134B0 /* TTExtensionLoader.m in Sources */,
+				90C3A1B6132BE3EB00AC06A2 /* UILabelAdditions.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
This non-breaking pull request provides some new features to extThree20CSSStyle module.
Samples provided in `samples/Style/TTCSSStyleSheets` project.
#1. Two macros to ease using CSS Stylesheets

```
 TTCSS(selector, variable)
```
- **selector**: a css selector like @"body"
- **variable**: **must** be one of: `color, backgroundColor, font, shadowColor, shadowOffset, shadowRadius`
  
  > Examples: `TTCSS(@"body", color)`, `TTCSS(@"buttonSave", shadowColor)`
  
    TTCSSSTATE(selector, variable, state)
- **selector, variable**: same as `TTCSS()`
- **state**: a UIControlState value
  
  > Example: `TTCSSSTATE(@"buttonSave", color, UIControlStateNormal)`
#2. Addition to UILabel class

```
 - (void)applyCssSelector:(NSString *)selector
```

This will apply the css selector values : `color, backgroundColor, font, shadowColor, shadowOffset, shadowRadius` when available in css stylesheet.
Radius is working for iOS > 3.2 by using `UILabel.layer.shadowXXX`

> Example: `[myLabel applyCssSelector:@"myHeader"];`
#3. Additions to TTStyles

`TTTextStyle` and `TTShadowStyle` _(and implicitly by inheritance `TTInnerShadowStyle`)_ have new constructors allowing using a CSS Selector.

> Examples :
>     [TTTextStyle styleWithCssSelector:@"myLabel" next:...]
>     [TTTextStyle styleWithCssSelector:@"myLabel" state:state next:...]
>     [TTShadowStyle styleWithCssSelector:@"myLabel" state:state next:...]
