### PR TITLE
Tturlrequest mod

### DIFF
--- a/src/Three20Network/Headers/TTErrorCodes.h
+++ b/src/Three20Network/Headers/TTErrorCodes.h
@@ -18,4 +18,4 @@
 
 extern NSString* const kTTNetworkErrorDomain;
 extern NSInteger const kTTNetworkErrorCodeInvalidImage;
-
+extern NSString* const kTTErrorResponseDataKey;

--- a/src/Three20Network/Sources/TTErrorCodes.m
+++ b/src/Three20Network/Sources/TTErrorCodes.m
@@ -18,4 +18,4 @@
 
 NSString* const kTTNetworkErrorDomain = @"three20.network";
 NSInteger const kTTNetworkErrorCodeInvalidImage = 100;
-
+NSString* const kTTErrorResponseDataKey = @"responsedata";

--- a/src/Three20Network/Sources/TTRequestLoader.m
+++ b/src/Three20Network/Sources/TTRequestLoader.m
@@ -16,6 +16,9 @@
 
 #import "Three20Network/private/TTRequestLoader.h"
 
+//Global
+#import "Three20Network/TTErrorCodes.h"
+
 // Network
 #import "Three20Network/TTGlobalNetwork.h"
 #import "Three20Network/TTURLRequest.h"
@@ -344,8 +347,13 @@ static const NSInteger kLoadMaxRetries = 2;
   } else {
     TTDCONDITIONLOG(TTDFLAG_URLREQUEST, @"  FAILED LOADING (%d) %@",
                     _response.statusCode, _urlPath);
-    NSError* error = [NSError errorWithDomain:NSURLErrorDomain code:_response.statusCode
-                                     userInfo:nil];
+	  NSDictionary* userInfo = [NSDictionary dictionaryWithObject:_responseData forKey:kTTErrorResponseDataKey];
+	  NSError* error = [NSError errorWithDomain:NSURLErrorDomain code:_response.statusCode
+									   userInfo:userInfo];
+	  /*
+	   NSError* error = [NSError errorWithDomain:NSURLErrorDomain code:_response.statusCode
+	   userInfo:nil];
+	   */
     [_queue loader:self didFailLoadWithError:error];
   }
 

--- a/src/Three20Network/Sources/TTURLRequest.m
+++ b/src/Three20Network/Sources/TTURLRequest.m
@@ -16,6 +16,7 @@
 
 #import "Three20Network/TTURLRequest.h"
 
+
 // Network
 #import "Three20Network/TTGlobalNetwork.h"
 #import "Three20Network/TTURLResponse.h"
@@ -157,7 +158,8 @@ static NSString* kStringBoundary = @"3i2ndDfv2rTHiSisAbouNdArYfORhtTPEefj3q2f";
 - (void)appendImageData:(NSData*)data
                withName:(NSString*)name
                  toBody:(NSMutableData*)body {
-  NSString *beginLine = [NSString stringWithFormat:@"\r\n--%@\r\n", kStringBoundary];
+  NSString *beginLine = [NSString stringWithFormat:@"--%@\r\n", kStringBoundary];
+	NSString *endLine = @"\r\n";
 
   [body appendData:[beginLine dataUsingEncoding:NSUTF8StringEncoding]];
   [body appendData:[[NSString stringWithFormat:
@@ -171,17 +173,17 @@ static NSString* kStringBoundary = @"3i2ndDfv2rTHiSisAbouNdArYfORhtTPEefj3q2f";
                       stringWithString:@"Content-Type: image/jpeg\r\n\r\n"]
                      dataUsingEncoding:_charsetForMultipart]];
   [body appendData:data];
+		[body appendData:[endLine dataUsingEncoding:NSUTF8StringEncoding]];
 }
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (NSData*)generatePostBody {
-  NSMutableData* body = [NSMutableData data];
-  NSString* beginLine = [NSString stringWithFormat:@"\r\n--%@\r\n", kStringBoundary];
 
-  [body appendData:[[NSString stringWithFormat:@"--%@\r\n", kStringBoundary]
-    dataUsingEncoding:NSUTF8StringEncoding]];
-
+	NSMutableData* body = [NSMutableData data];
+  NSString* beginLine = [NSString stringWithFormat:@"--%@\r\n", kStringBoundary];
+	NSString *endLine = @"\r\n";
+	
   for (id key in [_parameters keyEnumerator]) {
     NSString* value = [_parameters valueForKey:key];
     // Really, this can only be an NSString. We're cheating here.
@@ -192,6 +194,7 @@ static NSString* kStringBoundary = @"3i2ndDfv2rTHiSisAbouNdArYfORhtTPEefj3q2f";
         stringWithFormat:@"Content-Disposition: form-data; name=\"%@\"\r\n\r\n", key]
           dataUsingEncoding:_charsetForMultipart]];
       [body appendData:[value dataUsingEncoding:_charsetForMultipart]];
+		[body appendData:[endLine dataUsingEncoding:NSUTF8StringEncoding]];
     }
   }
 
@@ -227,9 +230,10 @@ static NSString* kStringBoundary = @"3i2ndDfv2rTHiSisAbouNdArYfORhtTPEefj3q2f";
     [body appendData:[[NSString stringWithFormat:@"Content-Type: %@\r\n\r\n", mimeType]
           dataUsingEncoding:_charsetForMultipart]];
     [body appendData:data];
+		[body appendData:[endLine dataUsingEncoding:NSUTF8StringEncoding]];
   }
 
-  [body appendData:[[NSString stringWithFormat:@"\r\n--%@--\r\n", kStringBoundary]
+  [body appendData:[[NSString stringWithFormat:@"--%@--\r\n", kStringBoundary]
                    dataUsingEncoding:NSUTF8StringEncoding]];
 
   // If an image was found, remove it from the dictionary to save memory while we


### PR DESCRIPTION
Working on my FriendFeed client (FFHound) i modified the network library, in spec:
1. now if the error is generated by an error code in 'connectionDidFinishLoading:(NSURLConnection *)connection', i add the response data into the NSError in 'kTTErrorResponseDataKey' so i can retrive the error' server later. This because the server reply with an error code (401, 403 etc..) but the response contains details on error;
2. using the 'official' post body in TTURLRequest all requests failed remaining 'hanged' so i 'rewrote' the method removing the "\r\n" in beginLine variable and adding the endLine variable.

Thanks
