### PR TITLE
Show menu animation

### DIFF
--- a/src/Three20UI/Sources/TTTableViewController.m
+++ b/src/Three20UI/Sources/TTTableViewController.m
@@ -818,7 +818,7 @@
   // Move each content subview down, revealing the menu
   for (UIView* subview in _menuCell.contentView.subviews) {
     if (subview != _menuView) {
-      subview.left -= _menuCell.contentView.width;
+      subview.right += _menuCell.contentView.width;
     }
   }
 
@@ -840,7 +840,7 @@
 
     for (UIView* view in _menuCell.contentView.subviews) {
       if (view != _menuView) {
-        view.left += _menuCell.contentView.width;
+        view.right -= _menuCell.contentView.width;
       }
     }
 


### PR DESCRIPTION
The default showMenu/hideMenu animation causes the table cell to slide out to the left and back in from the left, which is awkward in response to a standard swipe from left to right.  This change causes the cell to slide out to the right and back in from the right, which in my opinion is a bit more intuitive.
