### PR TITLE
Empty view fix

### DIFF
--- a/src/Three20UI/Sources/TTModelViewController.m
+++ b/src/Three20UI/Sources/TTModelViewController.m
@@ -150,7 +150,7 @@
   }
 
   if (!_flags.isShowingLoading && !_flags.isShowingModel && !_flags.isShowingError) {
-    showEmpty = !_flags.isShowingEmpty;
+	showEmpty = YES;
     _flags.isShowingEmpty = YES;
   } else {
     if (_flags.isShowingEmpty) {


### PR DESCRIPTION
In a few of my TTTableViewControllers, I use a segmented control that allows the user to change the data displayed in the tableview.  Upon changing context (e.g. responding to a segment selection event), I change out the tableview's datasource and cause the tableview to reload.  Given that these datasources display different information, they also have different empty views.  So, if I have a tableview that is switching between two different datasources based on user input, and both of these datasources is empty, the current behavior of the TTModelViewController causes the empty view for the datasource that is displayed at tableview load time to always show, regardless of whether or not I've switched out the underlying datasource, which may have a different empty view.

This change causes the TTModelViewController to always ask the datasource for the empty view, thus allowing me to switch back and forth between two datasources (with two different empty views) and have those empty views show properly.
