### PR TITLE
[UI] Fix TTTableImageItemCell default image bug

### DIFF
--- a/src/Three20UI/Sources/TTTableImageItemCell.m
+++ b/src/Three20UI/Sources/TTTableImageItemCell.m
@@ -147,7 +147,7 @@ static const CGFloat kDefaultImageSize = 50;
     ? image.size.height
     : (item.imageURL ? kDefaultImageSize : 0);
 
-    if (_imageView2.urlPath) {
+    if (_imageView2.urlPath || image) {
       CGFloat innerWidth = self.contentView.width - (kTableCellHPadding*2
                                                      + imageWidth + kKeySpacing);
       CGFloat innerHeight = self.contentView.height - kTableCellVPadding*2;
@@ -165,7 +165,7 @@ static const CGFloat kDefaultImageSize = 50;
     }
 
   } else {
-    if (_imageView2.urlPath) {
+    if (_imageView2.urlPath || image) {
       CGFloat iconWidth = image
       ? image.size.width
       : (item.imageURL ? kDefaultImageSize : 0);


### PR DESCRIPTION
Hi,

Here is a really small fix ;)
It fixes TTTableImageItemCell not displaying the default image when imageURL is nil.

This was originally submitted as part of the fixes in https://github.com/facebook/three20/pull/307 

To make it easier for you to merge it, it is now based off the facebook:development branch.

Thanks
