### PR TITLE
[UI] Fix TTStyledTextTableItemcell ignoring margin bug

### DIFF
--- a/src/Three20UI/Sources/TTStyledTextTableItemCell.m
+++ b/src/Three20UI/Sources/TTStyledTextTableItemCell.m
@@ -78,10 +78,12 @@ static const CGFloat kDisclosureIndicatorWidth = 23;
   if (item.URL) {
     padding += kDisclosureIndicatorWidth;
   }
+	
+  CGFloat margin = item.margin.left + item.margin.right;
 
-  item.text.width = tableView.width - padding;
+  item.text.width = tableView.width - padding - margin;
 
-  return item.text.height + item.padding.top + item.padding.bottom;
+  return item.text.height + item.padding.top + item.padding.bottom + item.margin.top + item.margin.bottom;
 }
 
 
@@ -96,7 +98,7 @@ static const CGFloat kDisclosureIndicatorWidth = 23;
   [super layoutSubviews];
 
   TTTableStyledTextItem* item = self.object;
-  _label.frame = CGRectOffset(self.contentView.bounds, item.margin.left, item.margin.top);
+  _label.frame = UIEdgeInsetsInsetRect(self.contentView.bounds, item.margin);
 }
 
 


### PR DESCRIPTION
Hi,

Here is again a really small fix ;)
It fixes TTStyledTextTableItemCell ignoring margin (courtesy of Aidan Dysart from the TThree20 mailing list: http://groups.google.com/group/three20/browse_thread/thread/48ca82d62f9509ab/01ae8ccd8428179d?hl=en&lnk=gst).

This was originally submitted as part of the fixes in https://github.com/facebook/three20/pull/307

To make it easier for you to merge it, it is now based off the facebook:development branch.

Thanks
