### PR TITLE
[UI] TTTableViewController support for clearsSelectionOnViewWillAppear

### DIFF
--- a/src/Three20UI/Headers/TTTableViewController.h
+++ b/src/Three20UI/Headers/TTTableViewController.h
@@ -39,6 +39,7 @@
 
   BOOL _variableHeightRows;
   BOOL _showTableShadows;
+  BOOL _clearsSelectionOnViewWillAppear;
 
   id<TTTableViewDataSource> _dataSource;
   id<UITableViewDelegate>   _tableDelegate;
@@ -87,6 +88,12 @@
  * empty cells for the remaining space. This causes the bottom shadow to appear out of place.
  */
 @property (nonatomic) BOOL showTableShadows;
+
+/**
+ * A Boolean value indicating if the controller clears the selection when the table appears.
+ * Default is YES.
+ */
+@property(nonatomic) BOOL clearsSelectionOnViewWillAppear;
 
 /**
  * Initializes and returns a controller having the given style.

--- a/src/Three20UI/Sources/TTTableViewController.m
+++ b/src/Three20UI/Sources/TTTableViewController.m
@@ -61,6 +61,7 @@
 @synthesize tableViewStyle      = _tableViewStyle;
 @synthesize variableHeightRows  = _variableHeightRows;
 @synthesize showTableShadows    = _showTableShadows;
+@synthesize clearsSelectionOnViewWillAppear = _clearsSelectionOnViewWillAppear;
 @synthesize dataSource          = _dataSource;
 
 
@@ -69,6 +70,7 @@
   if (self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil]) {
     _lastInterfaceOrientation = self.interfaceOrientation;
     _tableViewStyle = UITableViewStylePlain;
+    _clearsSelectionOnViewWillAppear = YES;
   }
 
   return self;
@@ -266,7 +268,9 @@
     tableView.showShadows = _showTableShadows;
   }
 
-  [_tableView deselectRowAtIndexPath:[_tableView indexPathForSelectedRow] animated:animated];
+  if (_clearsSelectionOnViewWillAppear) {
+    [_tableView deselectRowAtIndexPath:[_tableView indexPathForSelectedRow] animated:animated];
+  }
 }
 
 


### PR DESCRIPTION
Hi,

And now a tiny feature:
It adds support for clearsSelectionOnViewWillAppear in TTTableViewController (like in UITableViewController, http://developer.apple.com/library/ios/documentation/uikit/reference/UITableViewController_Class/Reference/Reference.html#//apple_ref/doc/uid/TP40007523-CH3-SW6).

This was originally submitted as part of the fixes in https://github.com/facebook/three20/pull/307

To make it easier for you to merge it, it is now based off the facebook:development branch.

Thanks
