### PR TITLE
Set the originalNavigatorURL when using hash-URLs (tt://controller#5) 

### DIFF
--- a/src/Three20UINavigator/Sources/TTBaseNavigator.m
+++ b/src/Three20UINavigator/Sources/TTBaseNavigator.m
@@ -692,13 +692,16 @@ __attribute__((weak_import));
     } else {
       id object = [_URLMap objectForURL:baseURL query:nil pattern:pattern];
       if (object) {
+        UIViewController *controller = nil;
         id result = [_URLMap dispatchURL:URL toTarget:object query:query];
         if ([result isKindOfClass:[UIViewController class]]) {
-          return result;
+          controller = result;
 
         } else {
-          return object;
+          controller = object;
         }
+        controller.originalNavigatorURL = baseURL;
+        return controller;
 
       } else {
         return nil;


### PR DESCRIPTION
When a hash-URL (like `tt://controller#(method:)`) is opened, the TTNavigator forgets to set the originalNavigatorURL of the controller when creating it.

That means if another hash-URL pointing to the same controller is called after that, the TTNavigator won't recognize the current controller, and will create and push a new one again.
#### Steps to reproduce

```
/* 1. */ [map from:@"tt://controller#(setSelectedPage:)" toViewController:[TTPagesController class]];
/* 2. */ TTOpenURL(@"tt://controller#1");
// later…
/* 3. */ TTOpenURL(@"tt://controller#5");
```
#### Expected behavior

On `3.`, the existing controller instance receives a `setSelectedPage:` message.
#### Observed behavior

On `3.`, a new controller is instanciated. This is because as the originalNavigatorURL wasn't set on the original instance, the TTNavigator can't figure out that `tt://controller#5` actually maps to a controller previously instanciated with `tt://controller#1`.
