### PR TITLE
Core Data

### DIFF
--- a/src/Three20UI/Headers/NSFetchedResultsDataSource.h
+++ b/src/Three20UI/Headers/NSFetchedResultsDataSource.h
@@ -1,0 +1,65 @@
+//
+//  NSFetchedResultsDataSource.h
+//  Shopify_Mobile
+//
+//  Created by Matt Newberry on 11/15/10.
+//  Copyright 2010 Shopify. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSFetchedResultsDataSource : TTSectionedDataSource <NSFetchedResultsControllerDelegate>{
+
+	NSFetchedResultsController *_fetchedResultsController;
+	UITableView *_tableView;
+	NSEntityDescription *_entity;
+	NSString *_sortBy;
+	NSArray *_selectFields;
+	NSString *_sectionKey;
+	NSPredicate *_predicate;
+	NSTimer *_updateTimer;
+	NSInteger _fetchLimit;
+	NSArray *_relationshipsToFetch;
+	NSMutableArray *_delegates;
+	
+	BOOL _isLoading;
+	BOOL _isOutdated;
+    BOOL _tableIsUpdating;
+    NSUInteger sectionInsertCount;
+}
+
+@property (nonatomic, assign) BOOL isOutdated;
+@property (nonatomic, retain) NSMutableArray *delegates;
+@property (nonatomic, assign) BOOL isLoading;
+@property (nonatomic, retain) NSArray *relationshipsToFetch;
+@property (nonatomic, assign) NSInteger fetchLimit;
+@property (nonatomic, retain) NSTimer *updateTimer;
+@property (nonatomic, retain) NSPredicate *predicate;
+@property (nonatomic, retain) NSString *sectionKey;
+@property (nonatomic, retain) NSString *sortBy;
+@property (nonatomic, retain) NSArray *selectFields;
+@property (nonatomic, retain) UITableView *tableView;
+@property (nonatomic, retain) NSFetchedResultsController *fetchedResultsController;
+@property (nonatomic, retain) NSEntityDescription *entity;
+
+- (id) initWithEntity:(NSEntityDescription *)entity controllerTableView:(UITableView *)controllerTableView;
+- (void) loadLocal:(BOOL)more;
+- (void) loadRemote;
+- (id) cellForObject:(id)object;
+
+- (void) didStartLoad;
+- (void) didLoad;
+- (void) didFailWithError:(NSError *)error;
+- (void) silentDidStartLoad;
+- (void) silentDidLoad;
+
+- (NSDate *) loadedTime;
+- (NSString*) titleForLoading:(BOOL)reloading;
+- (UIImage*) imageForEmpty;
+- (NSString*) titleForEmpty;
+- (NSString*) subtitleForEmpty;
+- (UIImage*) imageForError:(NSError*)error;
+- (NSString*) titleForError:(NSError*)error;
+- (NSString*) subtitleForError:(NSError*)error;
+
+@end

--- a/src/Three20UI/Headers/TTTableViewCoreDataController.h
+++ b/src/Three20UI/Headers/TTTableViewCoreDataController.h
@@ -1,0 +1,17 @@
+//
+//  TTTableViewCoreDataController.h
+//  Three20UI
+//
+//  Created by Matthew Newberry on 3/28/11.
+//  Copyright 2011 MNDCreative, LLC. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "TTTableViewController.h"
+
+@interface TTTableViewCoreDataController : TTTableViewController {
+    
+    BOOL _isLoading;
+}
+
+@end

--- a/src/Three20UI/Headers/Three20UI.h
+++ b/src/Three20UI/Headers/Three20UI.h
@@ -75,6 +75,7 @@
 #import "Three20UI/TTSearchBar.h"
 
 #import "Three20UI/TTTableViewController.h"
+#import "Three20UI/TTTableViewCoreDataController.h"
 #import "Three20UI/TTSearchDisplayController.h"
 #import "Three20UI/TTTableView.h"
 #import "Three20UI/TTTableViewDelegate.h"
@@ -89,7 +90,7 @@
 #import "Three20UI/TTSectionedDataSource.h"
 #import "Three20UI/TTTableHeaderView.h"
 #import "Three20UI/TTTableFooterInfiniteScrollView.h"
-#import "THree20UI/TTTableHeaderDragRefreshView.h"
+#import "Three20UI/TTTableHeaderDragRefreshView.h"
 #import "Three20UI/TTTableViewCell.h"
 
 // Table Items

--- a/src/Three20UI/Sources/NSFetchedResultsDataSource.m
+++ b/src/Three20UI/Sources/NSFetchedResultsDataSource.m
@@ -1,0 +1,407 @@
+//
+//  NSFetchedResultsDataSource.m
+//  Shopify_Mobile
+//
+//  Created by Matt Newberry on 11/15/10.
+//  Copyright 2010 Shopify. All rights reserved.
+//
+
+#import "NSFetchedResultsDataSource.h"
+
+#define FETCHED_DEBUG NO
+#define MAX_FETCH 50
+
+
+@implementation NSFetchedResultsDataSource
+
+@synthesize isOutdated = _isOutdated;
+@synthesize delegates = _delegates;
+@synthesize isLoading = _isLoading;
+@synthesize relationshipsToFetch = _relationshipsToFetch;
+@synthesize fetchLimit = _fetchLimit;
+@synthesize updateTimer = _updateTimer;
+@synthesize predicate = _predicate;
+@synthesize sectionKey = _sectionKey;
+@synthesize sortBy = _sortBy;
+@synthesize selectFields = _selectFields;
+@synthesize tableView = _tableView;
+@synthesize fetchedResultsController = _fetchedResultsController;
+@synthesize entity = _entity;
+
+- (id) initWithEntity:(NSEntityDescription *)entity controllerTableView:(UITableView *)controllerTableView{
+	
+	if(self = [super init]){
+		
+		self.entity = entity;
+		self.tableView = controllerTableView;
+		self.sortBy = [NSClassFromString([entity managedObjectClassName]) defaultSort];
+		self.sectionKey = @"section_key";
+		_selectFields = [[NSArray alloc] init];
+		self.fetchLimit = MAX_FETCH;
+		_isLoading = NO;
+		_isOutdated = NO;
+        _tableIsUpdating = NO;
+		_delegates = [[NSMutableArray alloc] init];
+	}
+	
+	return self;
+}
+
+- (void) loadLocal:(BOOL)more{
+	
+	TT_RELEASE_SAFELY(_fetchedResultsController);
+
+	NSFetchRequest *request = [[NSFetchRequest alloc] init];
+	[request setEntity:_entity];
+	[request setSortDescriptors:$SORT(_sortBy)];
+	[request setPropertiesToFetch:_selectFields];
+	[request setPredicate:_predicate];
+	[request setFetchLimit:_fetchLimit];
+	[request setFetchBatchSize:25];
+	
+	if(_relationshipsToFetch)
+		[request setRelationshipKeyPathsForPrefetching:_relationshipsToFetch];
+	    
+	_fetchedResultsController = [[NSFetchedResultsController alloc] initWithFetchRequest:request managedObjectContext:[ActiveManager shared].managedObjectContext sectionNameKeyPath:_sectionKey cacheName:nil];
+	_fetchedResultsController.delegate = self;
+	
+	NSError *error;
+	[_fetchedResultsController performFetch:&error];
+	[request release];
+}
+
+- (void) loadRemote{
+	
+	// Left empty to be overriden
+}
+
+- (id<TTModel>) model {
+	return self;
+}
+
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
+	
+    return [[_fetchedResultsController sections] count];
+}
+
+- (NSInteger)tableView:(UITableView *)table numberOfRowsInSection:(NSInteger)section {
+	
+    id <NSFetchedResultsSectionInfo> sectionInfo = [[_fetchedResultsController sections] objectAtIndex:section];
+    return [sectionInfo numberOfObjects];
+}
+
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section { 
+	
+    id <NSFetchedResultsSectionInfo> sectionInfo = [[_fetchedResultsController sections] objectAtIndex:section];
+    return [sectionInfo name];
+}
+
+
+- (id) tableView:(UITableView *)tableView objectForRowAtIndexPath:(NSIndexPath *)indexPath{
+	
+	id object = nil;
+	
+	@try {
+		object = [self cellForObject:[_fetchedResultsController objectAtIndexPath:indexPath]];
+	}
+	@catch (NSException * e) {
+		
+		// Do nothing, return object as nil
+	}	
+	
+	return object;
+}
+
+- (NSIndexPath *) tableView:(UITableView *)tableView indexPathForObject:(id)object{
+    
+    return [_fetchedResultsController indexPathForObject:object];
+}
+
+- (id) cellForObject:(id) object{
+	
+	return object;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (BOOL)isLoaded {
+	return _fetchedResultsController.fetchedObjects != nil;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (BOOL)isLoading {
+	return _isLoading;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (BOOL)isLoadingMore {
+	return NO;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (BOOL)isOutdated {
+	return _isOutdated;
+}
+
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)cancel {
+}
+
+
+#pragma mark -
+#pragma mark NSFetchedResultsControllerDelegate
+
+- (void)controllerWillChangeContent:(NSFetchedResultsController *)controller {
+    
+    sectionInsertCount = 0;
+    
+    if(_tableIsUpdating)
+        return;
+    
+    _tableIsUpdating = YES;
+
+    if(FETCHED_DEBUG)
+        NSLog(@"STARTING CHANGES");
+        
+    if(_delegates != nil)
+        [_delegates perform:@selector(modelDidBeginUpdates:) withObject:self];
+    else
+        [self.tableView beginUpdates];
+}
+
+
+- (void)controller:(NSFetchedResultsController *)controller didChangeSection:(id <NSFetchedResultsSectionInfo>)sectionInfo
+           atIndex:(NSUInteger)sectionIndex forChangeType:(NSFetchedResultsChangeType)type {
+	
+	switch(type) {
+		case NSFetchedResultsChangeInsert:
+            
+			[_delegates perform:@selector(model:didInsertObject:atIndexPath:) 
+					 withObject:self
+					 withObject:nil
+					 withObject:[NSIndexPath indexPathWithIndex:sectionIndex]
+			 ];
+			
+			if(FETCHED_DEBUG)
+				NSLog(@"Section Insert - %i", sectionIndex);
+            
+			break;
+			
+		case NSFetchedResultsChangeDelete:
+            
+			[_delegates perform:@selector(model:didDeleteObject:atIndexPath:) 
+					 withObject:self
+					 withObject:nil
+					 withObject:[NSIndexPath indexPathWithIndex:sectionIndex]
+			 ];
+			
+			if(FETCHED_DEBUG)
+				NSLog(@"Section Delete - %i", sectionIndex);
+			break;
+	}
+}
+
+
+- (void)controller:(NSFetchedResultsController *)controller didChangeObject:(id)anObject
+       atIndexPath:(NSIndexPath *)indexPath forChangeType:(NSFetchedResultsChangeType)type
+      newIndexPath:(NSIndexPath *)newIndexPath {
+    
+	switch(type) {
+			
+		case NSFetchedResultsChangeInsert:
+            
+			[_delegates perform:@selector(model:didInsertObject:atIndexPath:) 
+					 withObject:self
+					 withObject:anObject
+					 withObject:newIndexPath
+			 ];
+			
+			if(FETCHED_DEBUG)
+				NSLog(@"Row Insert - %@ - %@", newIndexPath, anObject);
+			
+			break;
+			
+		case NSFetchedResultsChangeDelete:
+            
+			[_delegates perform:@selector(model:didDeleteObject:atIndexPath:) 
+					 withObject:self
+					 withObject:anObject
+					 withObject:newIndexPath
+			 ];
+			
+			if(FETCHED_DEBUG)
+				NSLog(@"Row Deleted - %@", newIndexPath);
+            
+			break;
+			
+		case NSFetchedResultsChangeUpdate:
+            
+			[_delegates perform:@selector(model:didUpdateObject:atIndexPath:) 
+					 withObject:self
+					 withObject:anObject
+					 withObject:newIndexPath
+			 ];
+			
+			if(FETCHED_DEBUG)
+				NSLog(@"Row Updated - %@ - %@", newIndexPath, anObject);
+            
+			break;
+			
+		case NSFetchedResultsChangeMove:			
+			break;
+	}
+}
+
+- (NSIndexPath *) tableView:(UITableView *)tableView willInsertObject:(id)object atIndexPath:(NSIndexPath *)indexPath {
+
+	return indexPath;
+}
+
+- (NSIndexPath *) tableView:(UITableView *)tableView willRemoveObject:(id)object atIndexPath:(NSIndexPath *)indexPath {
+
+	return indexPath;
+}
+
+- (NSIndexPath *) tableView:(UITableView *)tableView willUpdateObject:(id)object atIndexPath:(NSIndexPath *)indexPath {
+	
+	return indexPath;
+}
+
+- (void)controllerDidChangeContent:(NSFetchedResultsController *)controller {
+    
+    _tableIsUpdating = NO;
+	
+    if(FETCHED_DEBUG)
+        NSLog(@"FINISHED CHANGES");
+        
+    if(_delegates != nil)
+        [_delegates perform:@selector(modelDidEndUpdates:) withObject:self];
+    else
+        [self.tableView endUpdates];
+}
+
+- (void) silentDidStartLoad{
+	
+	dispatch_async(dispatch_get_main_queue(), ^{
+		[[self delegates] perform:@selector(modelDidStartLoad:) withObject:self];
+	});
+}
+
+- (void) silentDidLoad{
+	
+	dispatch_async(dispatch_get_main_queue(), ^{
+		[[self delegates] perform:@selector(modelDidFinishLoad:) withObject:self];
+	});
+}
+
+- (void) didStartLoad{
+	
+	dispatch_async(dispatch_get_main_queue(), ^{
+		_isLoading = YES;
+		[[self delegates] perform:@selector(modelDidStartLoad:) withObject:self];
+	});
+}
+
+- (void) didLoad{
+	
+	dispatch_async(dispatch_get_main_queue(), ^{
+		_isLoading = NO;
+		_isOutdated = NO;
+		[[self delegates] perform:@selector(modelDidFinishLoad:) withObject:self];
+	});
+}
+
+- (void) didFailWithError:(NSError *)error{
+	
+	dispatch_async(dispatch_get_main_queue(), ^{
+		
+        _isLoading = NO;
+		_isOutdated = NO;
+		[[self delegates] perform:@selector(model:didFailLoadWithError:) withObject:self withObject:error];
+	});
+}
+
+- (NSDate *) loadedTime{
+	
+	return nil;
+}
+
+- (void) load:(TTURLRequestCachePolicy)cachePolicy more:(BOOL)more{
+	
+	if(cachePolicy == TTURLRequestCachePolicyNetwork)
+		[self loadRemote];
+	else
+		[self loadLocal:more];
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (NSString*)titleForLoading:(BOOL)reloading {
+	if (reloading) {
+		return TTLocalizedString(@"Updating...", @"");
+	} else {
+		return TTLocalizedString(@"Loading...", @"");
+	}
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (UIImage*)imageForEmpty {
+	return [self imageForError:nil];
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (NSString*)titleForEmpty {
+	return @"No Results Found";
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (NSString*)subtitleForEmpty {
+	return nil;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (UIImage*)imageForError:(NSError*)error {
+	return nil;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (NSString*)titleForError:(NSError*)error {
+	return TTDescriptionForError(error);
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (NSString*)subtitleForError:(NSError*)error {
+	return TTLocalizedString(@"Sorry, there was an error.", @"");
+}
+
+
+- (void)dealloc{
+	
+	[[NSNotificationCenter defaultCenter] removeObserver:self];
+	_fetchedResultsController.delegate = nil;
+	
+	TT_RELEASE_SAFELY(_fetchedResultsController);
+	TT_RELEASE_SAFELY(_entity);
+	TT_RELEASE_SAFELY(_tableView);
+	TT_RELEASE_SAFELY(_sortBy);
+	TT_RELEASE_SAFELY(_selectFields);
+	TT_RELEASE_SAFELY(_sectionKey);
+	TT_RELEASE_SAFELY(_predicate);
+	TT_RELEASE_SAFELY(_updateTimer);
+	TT_RELEASE_SAFELY(_relationshipsToFetch);
+	TT_RELEASE_SAFELY(_delegates);
+
+	[super dealloc];
+}
+
+@end

--- a/src/Three20UI/Sources/TTTableViewCoreDataController.m
+++ b/src/Three20UI/Sources/TTTableViewCoreDataController.m
@@ -1,0 +1,49 @@
+//
+//  TTTableViewCoreDataController.m
+//  Three20UI
+//
+//  Created by Matthew Newberry on 3/28/11.
+//  Copyright 2011 MNDCreative, LLC. All rights reserved.
+//
+
+#import "TTTableViewCoreDataController.h"
+
+@implementation TTTableViewCoreDataController
+
+- (void) modelDidStartLoad:(id <TTModel>)model{
+    
+    [super modelDidStartLoad:model];
+    
+    _isLoading = YES;
+}
+
+- (void) modelDidFinishLoad:(id<TTModel>)model{
+    
+    [super modelDidFinishLoad:model];
+    
+    _isLoading = NO;
+}
+
+- (void) modelDidBeginUpdates:(id<TTModel>)model{
+    
+    [super modelDidBeginUpdates:model];
+    
+    _isLoading = YES;
+}
+
+- (void) modelDidEndUpdates:(id<TTModel>)model{
+    
+    [super modelDidEndUpdates:model];
+    
+    _isLoading = NO;
+}
+
+- (void) updateView{
+    
+    if(_isLoading)
+        return;
+    
+    [super updateView];
+}
+
+@end


### PR DESCRIPTION
Spoke with jwang392 on IRC about this, it's not perfect, but a baseline I'm using for the Shopify mobile app. 

It works quite well actually until trying to invalidate the model and refresh the table. 

I had to wrap the TTTableViewController delegate methods for update, insert, and delete in @try blocks to prevent crashes, and manually try and go from there... Not good! 

The table typically will load the visible rows without issue in this manner, however when you try to scroll down, it's all blank data. 

I use this heavily with my ActiveRecord port to Objective-C that I wrote, https://github.com/MattNewberry/ObjectiveRecord

Makes it much easier to work with a remote Rails datasource. 
