### PR TITLE
Using UIViewAnimationTransition constants for transition 

### DIFF
--- a/src/Three20UINavigator/Headers/TTURLMap.h
+++ b/src/Three20UINavigator/Headers/TTURLMap.h
@@ -56,9 +56,11 @@
  */
 - (void)from:(NSString*)URL toViewController:(id)target;
 - (void)from:(NSString*)URL toViewController:(id)target selector:(SEL)selector;
-- (void)from:(NSString*)URL toViewController:(id)target transition:(NSInteger)transition;
+- (void)from:(NSString*)URL toViewController:(id)target
+        transition:(UIViewAnimationTransition)transition;
 - (void)from:(NSString*)URL parent:(NSString*)parentURL
-        toViewController:(id)target selector:(SEL)selector transition:(NSInteger)transition;
+        toViewController:(id)target selector:(SEL)selector
+        transition:(UIViewAnimationTransition)transition;
 
 /**
  * Adds a URL pattern which will create and present a share view controller when loaded.
@@ -78,9 +80,11 @@
  */
 - (void)from:(NSString*)URL toModalViewController:(id)target;
 - (void)from:(NSString*)URL toModalViewController:(id)target selector:(SEL)selector;
-- (void)from:(NSString*)URL toModalViewController:(id)target transition:(NSInteger)transition;
+- (void)from:(NSString*)URL toModalViewController:(id)target
+        transition:(UIViewAnimationTransition)transition;
 - (void)from:(NSString*)URL parent:(NSString*)parentURL
-        toModalViewController:(id)target selector:(SEL)selector transition:(NSInteger)transition;
+        toModalViewController:(id)target selector:(SEL)selector
+        transition:(UIViewAnimationTransition)transition;
 
 - (void)from:(NSString*)URL toPopoverViewController:(id)target;
 - (void)from:(NSString*)URL toPopoverViewController:(id)target selector:(SEL)selector;
@@ -148,7 +152,7 @@
 /**
  * Tests if there is a pattern that matches the URL and if so returns its transition.
  */
-- (NSInteger)transitionForURL:(NSString*)URL;
+- (UIViewAnimationTransition)transitionForURL:(NSString*)URL;
 
 /**
  * Returns YES if there is a registered pattern with the URL scheme.

--- a/src/Three20UINavigator/Sources/TTURLMap.m
+++ b/src/Three20UINavigator/Sources/TTURLMap.m
@@ -217,7 +217,8 @@
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-- (void)from:(NSString*)URL toViewController:(id)target transition:(NSInteger)transition {
+- (void)from:(NSString*)URL toViewController:(id)target
+        transition:(UIViewAnimationTransition)transition {
   TTURLNavigatorPattern* pattern = [[TTURLNavigatorPattern alloc] initWithTarget:target
                                                                   mode:TTNavigationModeCreate];
   pattern.transition = transition;
@@ -228,7 +229,8 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)from:(NSString*)URL parent:(NSString*)parentURL
-        toViewController:(id)target selector:(SEL)selector transition:(NSInteger)transition {
+        toViewController:(id)target selector:(SEL)selector
+        transition:(UIViewAnimationTransition)transition {
   TTURLNavigatorPattern* pattern = [[TTURLNavigatorPattern alloc] initWithTarget:target
                                                                   mode:TTNavigationModeCreate];
   pattern.parentURL = parentURL;
@@ -301,7 +303,8 @@
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-- (void)from:(NSString*)URL toModalViewController:(id)target transition:(NSInteger)transition {
+- (void)from:(NSString*)URL toModalViewController:(id)target
+        transition:(UIViewAnimationTransition)transition {
   TTURLNavigatorPattern* pattern = [[TTURLNavigatorPattern alloc] initWithTarget:target
                                                                   mode:TTNavigationModeModal];
   pattern.transition = transition;
@@ -312,7 +315,8 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)from:(NSString*)URL parent:(NSString*)parentURL
-        toModalViewController:(id)target selector:(SEL)selector transition:(NSInteger)transition {
+        toModalViewController:(id)target selector:(SEL)selector
+        transition:(UIViewAnimationTransition)transition {
   TTURLNavigatorPattern* pattern = [[TTURLNavigatorPattern alloc] initWithTarget:target
                                                                   mode:TTNavigationModeModal];
   pattern.parentURL = parentURL;
@@ -490,7 +494,7 @@
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-- (NSInteger)transitionForURL:(NSString*)URL {
+- (UIViewAnimationTransition)transitionForURL:(NSString*)URL {
   TTURLNavigatorPattern* pattern = [self matchObjectPattern:[NSURL URLWithString:URL]];
   return pattern.transition;
 }


### PR DESCRIPTION
Apple APIs are using UIViewAnimationTransition constants in their UIKit classes and would probably be a good idea to use it in the TTURLMap as well.

http://developer.apple.com/library/ios/#documentation/uikit/reference/UIView_Class/UIView/UIView.html 
- UIKit headers are already included in TTURLMap header
