### PR TITLE
Use a "counting semaphore" for suspending network over using a boolean switch

### DIFF
--- a/src/Three20Network/Headers/TTURLRequestQueue.h
+++ b/src/Three20Network/Headers/TTURLRequestQueue.h
@@ -34,6 +34,7 @@
   CGFloat               _imageCompressionQuality;
 
   BOOL                  _suspended;
+  NSInteger             _suspendedSemaphore;
 }
 
 /**

--- a/src/Three20Network/Sources/TTURLRequestQueue.m
+++ b/src/Three20Network/Sources/TTURLRequestQueue.m
@@ -320,8 +320,9 @@ static TTURLRequestQueue* gMainQueue = nil;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)setSuspended:(BOOL)isSuspended {
-  TTDCONDITIONLOG(TTDFLAG_URLREQUEST, @"SUSPEND LOADING %d", isSuspended);
-  _suspended = isSuspended;
+  _suspendedSemaphore = isSuspended ? _suspendedSemaphore + 1 : fmax(0, _suspendedSemaphore - 1);
+  _suspended = _suspendedSemaphore != 0;
+  TTDCONDITIONLOG(TTDFLAG_URLREQUEST, @"SUSPEND LOADING %d", _suspended);  
 
   if (!_suspended) {
     [self loadNextInQueue];


### PR DESCRIPTION
Currently, suspending network activity uses a boolean flag rather than a value. This can cause issue when there are multiple actors that use this flag.

For example,

Actor 1 -> Suspend Queue
Actor 2 -> Suspend Queue
Actor 1 -> Enables Queue
Actor 3 -> Starts network activity that depends on result of Actor 2
Actor 2 -> Enables Queue (again)

A semaphore would resolve this particular issue, so long as the semaphore is managed only on the main thread.
