### PR TITLE
Fix incorrectly retained model in tableViewController delegates

### DIFF
--- a/src/Three20UI/Sources/TTTableViewController.m
+++ b/src/Three20UI/Sources/TTTableViewController.m
@@ -935,11 +935,9 @@
   // Renew the tableView delegate when the model is refreshed.
   // Otherwise the delegate will be retained the model.
 
-  [_tableDelegate release];
-  _tableDelegate = [[self createDelegate] retain];
   // You need to set it to nil before changing it or it won't have any effect
   _tableView.delegate = nil;
-  _tableView.delegate = _tableDelegate;
+  [self updateTableDelegate];
 }
 
 @end

--- a/src/Three20UI/Sources/TTTableViewController.m
+++ b/src/Three20UI/Sources/TTTableViewController.m
@@ -123,9 +123,12 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)updateTableDelegate {
   if (!_tableView.delegate) {
+    [_tableDelegate release];
+    _tableDelegate = [[self createDelegate] retain];
+
     // You need to set it to nil before changing it or it won't have any effect
     _tableView.delegate = nil;
-    [self updateTableDelegate];
+    _tableView.delegate = _tableDelegate;
   }
 }
 

--- a/src/Three20UI/Sources/TTTableViewController.m
+++ b/src/Three20UI/Sources/TTTableViewController.m
@@ -931,4 +931,18 @@
 }
 
 
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)invalidateModel {
+  [super invalidateModel];
+
+  // Renew the tableView delegate when the model is refreshed.
+  // Otherwise the delegate will be retained the model.
+
+  [_tableDelegate release];
+  _tableDelegate = [[self createDelegate] retain];
+  // You need to set it to nil before changing it or it won't have any effect
+  _tableView.delegate = nil;
+  _tableView.delegate = _tableDelegate;
+}
+
 @end

--- a/src/Three20UI/Sources/TTTableViewController.m
+++ b/src/Three20UI/Sources/TTTableViewController.m
@@ -123,12 +123,9 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)updateTableDelegate {
   if (!_tableView.delegate) {
-    [_tableDelegate release];
-    _tableDelegate = [[self createDelegate] retain];
-
     // You need to set it to nil before changing it or it won't have any effect
     _tableView.delegate = nil;
-    _tableView.delegate = _tableDelegate;
+    [self updateTableDelegate];
   }
 }
 

--- a/src/extThree20CSSStyle/Sources/TTCSSStyleSheet.m
+++ b/src/extThree20CSSStyle/Sources/TTCSSStyleSheet.m
@@ -52,7 +52,7 @@ NSString* kKeyTextShadowColor   = @"color";
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (id)init {
-  if (self = [super init]) {
+  if ((self = [super init])) {
     [[NSNotificationCenter defaultCenter]
      addObserver: self
      selector: @selector(didReceiveMemoryWarning:)
@@ -394,8 +394,7 @@ NSString* kKeyTextShadowColor   = @"color";
 
         NSArray* fontFamilyValues = [ruleSet objectForKey:kCssPropertyFontFamily];
         if ([fontFamilyValues count] > 0) {
-          NSArray* systemFontFamilyNames = [UIFont familyNames];
-          TTDINFO(@"Font families: %@", systemFontFamilyNames);
+          TTDINFO(@"Font families: %@", [UIFont familyNames]);
           for (NSString* fontName in fontFamilyValues) {
           }
           if ([[fontFamilyValues objectAtIndex:0] isEqualToString:@"bold"]) {

--- a/src/extThree20CSSStyle/Sources/TTCSSStyleSheet.m
+++ b/src/extThree20CSSStyle/Sources/TTCSSStyleSheet.m
@@ -52,7 +52,7 @@ NSString* kKeyTextShadowColor   = @"color";
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (id)init {
-  if ((self = [super init])) {
+  if (self = [super init]) {
     [[NSNotificationCenter defaultCenter]
      addObserver: self
      selector: @selector(didReceiveMemoryWarning:)
@@ -394,7 +394,8 @@ NSString* kKeyTextShadowColor   = @"color";
 
         NSArray* fontFamilyValues = [ruleSet objectForKey:kCssPropertyFontFamily];
         if ([fontFamilyValues count] > 0) {
-          TTDINFO(@"Font families: %@", [UIFont familyNames]);
+          NSArray* systemFontFamilyNames = [UIFont familyNames];
+          TTDINFO(@"Font families: %@", systemFontFamilyNames);
           for (NSString* fontName in fontFamilyValues) {
           }
           if ([[fontFamilyValues objectAtIndex:0] isEqualToString:@"bold"]) {


### PR DESCRIPTION
Added an invalidateModel method to TTTableViewController to prevent that the underlying model is retained in the view controller delegate. 

Issue can be reproduced by registering networkEnabledDelegate in the tvc, then calling [self invalidateModel] from the tvc. The model used in the networkEnabledDelegate will still be the old one. By implementing this fix, the delegate is canned and recreated with the new model created in [super invalidateModel].
