### PR TITLE
[fix] TTTableControlCell unproperly remove controls from cell 

### DIFF
--- a/src/Three20UI/Sources/TTTableControlCell.m
+++ b/src/Three20UI/Sources/TTTableControlCell.m
@@ -192,7 +192,8 @@ static const CGFloat kControlPadding = 8;
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)setObject:(id)object {
   if (object != _control && object != _item) {
-    [_control removeFromSuperview];
+    if (_control.superview == self.contentView)
+      [_control removeFromSuperview];
     TT_RELEASE_SAFELY(_control);
     TT_RELEASE_SAFELY(_item);
 


### PR DESCRIPTION
[fix] TTTableControlCell unproperly remove controls from cell on setting Object without checking it holds it. Makes Tables with many controls lose some while scrolling on cell reusing.

That's the second time I fix that bug on my side, checked issues, and a fix has already been proposed, which is the same I found on my side, so I confirm this works.

For more details see #139, and this commit noahmiller/three20@577af26ed, similar to my pull request.
