### PR TITLE
[extThree20CSS] suppressed variable warning

### DIFF
--- a/src/extThree20CSSStyle/Sources/TTCSSStyleSheet.m
+++ b/src/extThree20CSSStyle/Sources/TTCSSStyleSheet.m
@@ -394,8 +394,7 @@ NSString* kKeyTextShadowColor   = @"color";
 
         NSArray* fontFamilyValues = [ruleSet objectForKey:kCssPropertyFontFamily];
         if ([fontFamilyValues count] > 0) {
-          NSArray* systemFontFamilyNames = [UIFont familyNames];
-          TTDINFO(@"Font families: %@", systemFontFamilyNames);
+          TTDINFO(@"Font families: %@", [UIFont familyNames]);
           for (NSString* fontName in fontFamilyValues) {
           }
           if ([[fontFamilyValues objectAtIndex:0] isEqualToString:@"bold"]) {


### PR DESCRIPTION
Removed variable warning, TTDINFO being compiled to nothing because of default debug level.

related to facebook/three20@c8d1155537
