### PR TITLE
Added editable property to TTLauncherView

### DIFF
--- a/src/Three20UI/Headers/TTLauncherView.h
+++ b/src/Three20UI/Headers/TTLauncherView.h
@@ -49,6 +49,7 @@
 
   BOOL _editing;
   BOOL _springing;
+  BOOL _editable;
 
   id<TTLauncherViewDelegate> _delegate;
 }
@@ -68,6 +69,7 @@
 @property (nonatomic, copy) NSString* prompt;
 
 @property (nonatomic, readonly) BOOL editing;
+@property (nonatomic, assign) BOOL editable;
 
 - (void)addItem:(TTLauncherItem*)item animated:(BOOL)animated;
 

--- a/src/Three20UI/Sources/TTLauncherView.m
+++ b/src/Three20UI/Sources/TTLauncherView.m
@@ -68,7 +68,7 @@ static const NSInteger kDefaultColumnCount = 3;
 @synthesize prompt      = _prompt;
 @synthesize editing     = _editing;
 @synthesize delegate    = _delegate;
-
+@synthesize editable	= _editable;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (id)initWithFrame:(CGRect)frame {
@@ -97,6 +97,7 @@ static const NSInteger kDefaultColumnCount = 3;
 
     self.autoresizesSubviews = YES;
     self.columnCount = kDefaultColumnCount;
+    self.editable = YES;
   }
 
   return self;
@@ -482,6 +483,9 @@ static const NSInteger kDefaultColumnCount = 3;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)buttonTouchedDown:(TTLauncherButton*)button withEvent:(UIEvent*)event {
+  if (!_editable)
+    return;
+
   if (_editing) {
     if (!_dragButton) {
       [self startDraggingButton:button withEvent:event];


### PR DESCRIPTION
Sometimes it's usefult to not allow the user to change the order of items in a TTLauncherView.
The new editable property allows such control, defaulting to the old behaviour .
