### PR TITLE
[UI] Implement prepareForReuse in the subtitle item cell in order to correctly reset the cell's contents. 

### DIFF
--- a/src/Three20UI/Sources/TTTableSubtitleItemCell.m
+++ b/src/Three20UI/Sources/TTTableSubtitleItemCell.m
@@ -130,6 +130,17 @@
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)prepareForReuse {
+  [super prepareForReuse];
+
+  self.textLabel.text = nil;
+  self.detailTextLabel.text = nil;
+  self.imageView2.defaultImage = nil;
+  self.imageView2.urlPath = nil;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)setObject:(id)object {
   if (_item != object) {
     [super setObject:object];

--- a/src/Three20UI/Sources/TTTableSubtitleItemCell.m
+++ b/src/Three20UI/Sources/TTTableSubtitleItemCell.m
@@ -130,33 +130,23 @@
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-- (void)prepareForReuse {
-  [super prepareForReuse];
-
-  self.textLabel.text = nil;
-  self.detailTextLabel.text = nil;
-  self.imageView2.defaultImage = nil;
-  self.imageView2.urlPath = nil;
-}
-
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)setObject:(id)object {
   if (_item != object) {
     [super setObject:object];
 
     TTTableSubtitleItem* item = object;
-    if (item.text.length) {
-      self.textLabel.text = item.text;
-    }
-    if (item.subtitle.length) {
-      self.detailTextLabel.text = item.subtitle;
-    }
-    if (item.defaultImage) {
+    self.textLabel.text = item.text;
+    self.detailTextLabel.text = item.subtitle;
+
+    if (item.defaultImage || item.imageURL) {
       self.imageView2.defaultImage = item.defaultImage;
-    }
-    if (item.imageURL) {
       self.imageView2.urlPath = item.imageURL;
+
+    } else {
+      // Subviews are laid out in this cell depending on the existence of the image view.
+      // If there is no image to be displayed, we remove the image view altogether.
+      [_imageView2 removeFromSuperview];
+      TT_RELEASE_SAFELY(_imageView2);
     }
   }
 }


### PR DESCRIPTION
Before this change, subtitle cells would not unset their view information correctly when reused, causing incorrect information to appear on cells.
