### PR TITLE
Styled text alignment

### DIFF
--- a/src/Three20Style/Headers/TTStyledLayout.h
+++ b/src/Three20Style/Headers/TTStyledLayout.h
@@ -44,6 +44,7 @@
   UIFont* _font;
   UIFont* _boldFont;
   UIFont* _italicFont;
+  UITextAlignment _textAlignment;
 
   TTStyle*      _linkStyle;
   TTStyledNode* _rootNode;
@@ -55,6 +56,7 @@
 @property (nonatomic)           CGFloat         width;
 @property (nonatomic)           CGFloat         height;
 @property (nonatomic, retain)   UIFont*         font;
+@property (nonatomic)           UITextAlignment textAlignment;
 @property (nonatomic, readonly) TTStyledFrame*  rootFrame;
 @property (nonatomic, retain)   NSMutableArray* invalidImages;
 

--- a/src/Three20Style/Headers/TTStyledText.h
+++ b/src/Three20Style/Headers/TTStyledText.h
@@ -28,6 +28,7 @@
   TTStyledNode*   _rootNode;
   TTStyledFrame*  _rootFrame;
   UIFont*         _font;
+  UITextAlignment _textAlignment;
   CGFloat         _width;
   CGFloat         _height;
   NSMutableArray* _invalidImages;
@@ -52,6 +53,11 @@
  * The font that will be used to measure and draw all text.
  */
 @property (nonatomic, retain) UIFont* font;
+
+/**
+ * The alignment of the text.
+ */
+@property (nonatomic) UITextAlignment textAlignment;
 
 /**
  * The width that the text should be constrained to fit within.

--- a/src/Three20Style/Headers/TTStyledTextFrame.h
+++ b/src/Three20Style/Headers/TTStyledTextFrame.h
@@ -23,6 +23,7 @@
   TTStyledTextNode* _node;
   NSString*         _text;
   UIFont*           _font;
+  UITextAlignment   _textAlignment;
 }
 
 /**
@@ -39,6 +40,11 @@
  * The font that is used to measure and display the text of this frame.
  */
 @property (nonatomic, retain) UIFont* font;
+
+/**
+ * The alignment of the text.
+ */
+@property (nonatomic) UITextAlignment textAlignment;
 
 - (id)initWithText:(NSString*)text element:(TTStyledElement*)element node:(TTStyledTextNode*)node;
 

--- a/src/Three20Style/Sources/TTStyledLayout.m
+++ b/src/Three20Style/Sources/TTStyledLayout.m
@@ -367,16 +367,20 @@
   }
 
   // Horizontally align all frames on the current line
-	TTStyledFrame* frame = _lineFirstFrame;
-	while (frame) {
-		if (_textAlignment == UITextAlignmentRight) {
-			[self offsetFrame:frame byX:_width - _lineWidth];
-
-		} else if (_textAlignment == UITextAlignmentCenter) {
-			[self offsetFrame:frame byX:floor((_width - _lineWidth) / 2.0)];
-		}
-		frame = frame.nextFrame;
-	}
+  if (_textAlignment != UITextAlignmentLeft) {
+    CGFloat offset = 0;
+    if (_textAlignment == UITextAlignmentRight) {
+      offset = _width - _lineWidth;
+      
+    } else if (_textAlignment == UITextAlignmentCenter) {
+      offset = floor((_width - _lineWidth) / 2);
+    }
+    TTStyledFrame* frame = _lineFirstFrame;
+    while (frame) {
+      [self offsetFrame:frame byX:offset];
+      frame = frame.nextFrame;
+    }
+  }
 
   _height += _lineHeight;
   [self checkFloats];

--- a/src/Three20Style/Sources/TTStyledText.m
+++ b/src/Three20Style/Sources/TTStyledText.m
@@ -57,6 +57,7 @@
 
 @synthesize rootNode      = _rootNode;
 @synthesize font          = _font;
+@synthesize textAlignment = _textAlignment;
 @synthesize width         = _width;
 @synthesize height        = _height;
 @synthesize invalidImages = _invalidImages;
@@ -301,6 +302,15 @@
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)setTextAlignment:(UITextAlignment)textAlignment {
+	if (textAlignment != _textAlignment) {
+		_textAlignment = textAlignment;
+		[self setNeedsLayout];
+	}
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)setWidth:(CGFloat)width {
   if (width != _width) {
     _width = width;
@@ -327,6 +337,7 @@
   TTStyledLayout* layout = [[TTStyledLayout alloc] initWithRootNode:_rootNode];
   layout.width = _width;
   layout.font = _font;
+  layout.textAlignment = _textAlignment;
   [layout layout:_rootNode];
 
   [_rootFrame release];

--- a/src/Three20Style/Sources/TTStyledTextFrame.m
+++ b/src/Three20Style/Sources/TTStyledTextFrame.m
@@ -25,9 +25,10 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 @implementation TTStyledTextFrame
 
-@synthesize node = _node;
-@synthesize text = _text;
-@synthesize font = _font;
+@synthesize node          = _node;
+@synthesize text          = _text;
+@synthesize font          = _font;
+@synthesize textAlignment = _textAlignment;
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -58,7 +59,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)drawInRect:(CGRect)rect {
-  [_text drawInRect:rect withFont:_font lineBreakMode:UILineBreakModeClip];
+	[_text drawInRect:rect withFont:_font lineBreakMode:UILineBreakModeClip alignment:_textAlignment];
 }
 
 

--- a/src/Three20UI/Headers/TTStyledTextLabel.h
+++ b/src/Three20UI/Headers/TTStyledTextLabel.h
@@ -68,7 +68,7 @@
 @property (nonatomic, retain) UIColor* highlightedTextColor;
 
 /**
- * The alignment of the text. (NOT YET IMPLEMENTED)
+ * The alignment of the text.
  */
 @property (nonatomic) UITextAlignment textAlignment;
 

--- a/src/Three20UI/Sources/TTStyledTextLabel.m
+++ b/src/Three20UI/Sources/TTStyledTextLabel.m
@@ -454,6 +454,7 @@ static const CGFloat kCancelHighlightThreshold = 4;
     _text = [text retain];
     _text.delegate = self;
     _text.font = _font;
+    _text.textAlignment = _textAlignment;
     [self setNeedsLayout];
     [self setNeedsDisplay];
   }
@@ -521,6 +522,16 @@ static const CGFloat kCancelHighlightThreshold = 4;
       [_highlightedNode release];
       _highlightedNode = [node retain];
     }
+  }
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)setTextAlignment:(UITextAlignment)textAlignment {
+  if (textAlignment != _textAlignment) {
+    _textAlignment = textAlignment;
+    _text.textAlignment = textAlignment;
+    [self setNeedsLayout];
   }
 }
 


### PR DESCRIPTION
Hi Three20 team,

I've been working with Three20 for a while and have always wanted to make a contribution.  I'd be very happy if you looked at my pull request to see if this addition is worth integrating.

So for the longest time TTStyledTextLabel's textAlignment property had a big "NOT YET IMPLEMENTED" comment next to it.  I needed a styled label with left alignment for a Hebrew-language app so I went ahead and implemented this.  Center alignment is also working.

It's a pretty simple update and shouldn't give you too much trouble.  My commit messages have implementation details.  Let me know if you have any concerns.

Best,
Sean Meador
