### PR TITLE
[NETWORK] TTURLCaches loadImageFromDocuments Method not loading Retina Images

### DIFF
--- a/src/Three20Network/Sources/TTURLCache.m
+++ b/src/Three20Network/Sources/TTURLCache.m
@@ -262,8 +262,7 @@ static NSMutableDictionary* gNamedCaches = nil;
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (UIImage*)loadImageFromDocuments:(NSString*)URL {
   NSString* path = TTPathForDocumentsResource([URL substringFromIndex:12]);
-  NSData* data = [NSData dataWithContentsOfFile:path];
-  return [UIImage imageWithData:data];
+  return [UIImage imageWithContentsOfFile:path];
 }
 
 


### PR DESCRIPTION
fixed TTURLCache causing loadImageFromDocuments not returning Retina Images.

Tried to add TTLauncherItems with Images form the Documents Directory. Ended up with this solution
