### PR TITLE
[UICommon] TTDeviceOrientationIsPortrait() and TTDeviceOrientationIsLandscape() helper functions

### DIFF
--- a/src/Three20UICommon/Headers/TTGlobalUICommon.h
+++ b/src/Three20UICommon/Headers/TTGlobalUICommon.h
@@ -48,6 +48,16 @@ BOOL TTIsPad();
 UIDeviceOrientation TTDeviceOrientation();
 
 /**
+ * @return TRUE if the current device orientation is portrait or portrait upside down.
+ */
+BOOL TTDeviceOrientationIsPortrait();
+
+/**
+ * @return TRUE if the current device orientation is landscape left, or landscape right.
+ */
+BOOL TTDeviceOrientationIsLandscape();
+
+/**
  * On iPhone/iPod touch
  * Checks if the orientation is portrait, landscape left, or landscape right.
  * This helps to ignore upside down and flat orientations.

--- a/src/Three20UICommon/Sources/TTGlobalUICommon.m
+++ b/src/Three20UICommon/Sources/TTGlobalUICommon.m
@@ -121,6 +121,34 @@ UIDeviceOrientation TTDeviceOrientation() {
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
+BOOL TTDeviceOrientationIsPortrait() {
+  UIDeviceOrientation orient = TTDeviceOrientation();
+
+  switch (orient) {
+    case UIInterfaceOrientationPortrait:
+    case UIInterfaceOrientationPortraitUpsideDown:
+      return YES;
+    default:
+      return NO;
+  }
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+BOOL TTDeviceOrientationIsLandscape() {
+  UIDeviceOrientation orient = TTDeviceOrientation();
+
+  switch (orient) {
+    case UIInterfaceOrientationLandscapeLeft:
+    case UIInterfaceOrientationLandscapeRight:
+      return YES;
+    default:
+      return NO;
+  }
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
 BOOL TTIsSupportedOrientation(UIInterfaceOrientation orientation) {
   if (TTIsPad()) {
     return YES;


### PR DESCRIPTION
Two helper functions which saved me many code lines in my UIViews.

These two new functions use TTDeviceOrientation() to easily check if the device is either in landscape or portrait mode.

The functions follow the naming of apple's UIInterfaceOrientationIsLandscape & UIInterfaceOrientationIsPortrait functions, which are a little annoying to use, as they must accept existing orientation.
