### PR TITLE
Fix speechbubble

### DIFF
--- a/samples/TTCatalog/Classes/StyleTestController.m
+++ b/samples/TTCatalog/Classes/StyleTestController.m
@@ -45,20 +45,49 @@
     [TTSolidFillStyle styleWithColor:[UIColor whiteColor] next:
     [TTSolidBorderStyle styleWithColor:black width:1 next:nil]]],
 
-    // SpeechBubble
-    [TTShapeStyle styleWithShape:[TTSpeechBubbleShape shapeWithRadius:5 pointLocation:60
-                                                      pointAngle:90
-                                                      pointSize:CGSizeMake(20,10)] next:
-    [TTSolidFillStyle styleWithColor:[UIColor whiteColor] next:
-    [TTSolidBorderStyle styleWithColor:black width:1 next:nil]]],
+    // SpeechBubble with pointer left of the centre on the top edge
+    // Locations for top edge are 45 on the left, 90 in the centre, 134.999 on the right
+    [TTShapeStyle styleWithShape:[TTSpeechBubbleShape shapeWithRadius:5 
+                                                        pointLocation:60
+                                                           pointAngle:90
+                                                            pointSize:CGSizeMake(20,10)] next:
+     [TTSolidFillStyle styleWithColor:[UIColor whiteColor] next:
+      [TTSolidBorderStyle styleWithColor:black width:1 next:nil]]],
 
-    // SpeechBubble
-    [TTShapeStyle styleWithShape:[TTSpeechBubbleShape shapeWithRadius:5 pointLocation:290
-                                                      pointAngle:270
-                                                      pointSize:CGSizeMake(20,10)] next:
-    [TTSolidFillStyle styleWithColor:[UIColor whiteColor] next:
-    [TTSolidBorderStyle styleWithColor:black width:1 next:nil]]],
-
+     // SpeechBubble with pointer on the extreme left on the bottom edge
+     // Locations for bottom edge are 225 on the left, 270 in the centre, 314.999 on the left
+    [TTShapeStyle styleWithShape:[TTSpeechBubbleShape shapeWithRadius:5 
+                                                        pointLocation:314
+                                                           pointAngle:270
+                                                            pointSize:CGSizeMake(20,10)] next:
+     [TTSolidFillStyle styleWithColor:[UIColor whiteColor] next:
+      [TTSolidBorderStyle styleWithColor:black width:1 next:nil]]],
+    
+    // SpeechBubble with pointer on the bottom of the left edge
+    // Locations for left edge are 315 on the bottom, 0 in the centre, 44.999 on top
+    [TTShapeStyle styleWithShape:[TTSpeechBubbleShape shapeWithRadius:5 
+                                                        pointLocation:315
+                                                           pointAngle:0
+                                                            pointSize:CGSizeMake(10,20)] next:
+     [TTSolidFillStyle styleWithColor:[UIColor whiteColor] next:
+      [TTSolidBorderStyle styleWithColor:black width:1 next:nil]]],
+    
+    // SpeechBubble with pointer on the centre of the left edge
+    // Locations for left edge are 315 on the bottom, 0 in the centre, 44.999 on top
+    [TTShapeStyle styleWithShape:[TTSpeechBubbleShape shapeWithRadius:5 pointLocation:0
+                                                           pointAngle:0
+                                                            pointSize:CGSizeMake(20,10)] next:
+     [TTSolidFillStyle styleWithColor:[UIColor whiteColor] next:
+      [TTSolidBorderStyle styleWithColor:black width:1 next:nil]]],
+    
+    // SpeechBubble with pointer on the bottom of the right hand edge
+    // Locations for right edge are 135 on top, 180 in the middle, 314.999 on the bottom
+    [TTShapeStyle styleWithShape:[TTSpeechBubbleShape shapeWithRadius:5 pointLocation:224
+                                                           pointAngle:180
+                                                            pointSize:CGSizeMake(15,15)] next:
+     [TTSolidFillStyle styleWithColor:[UIColor whiteColor] next:
+      [TTSolidBorderStyle styleWithColor:black width:1 next:nil]]],
+    
     // Drop shadow
     [TTShapeStyle styleWithShape:[TTRoundedRectangleShape shapeWithRadius:10] next:
     [TTShadowStyle styleWithColor:RGBACOLOR(0,0,0,0.5) blur:5 offset:CGSizeMake(2, 2) next:

--- a/src/Three20Style/Headers/TTSpeechBubbleShape.h
+++ b/src/Three20Style/Headers/TTSpeechBubbleShape.h
@@ -17,6 +17,10 @@
 // Style
 #import "Three20Style/TTShape.h"
 
+/**
+ * The shape that defines a rectangular shape with a pointer.
+ *
+ */
 @interface TTSpeechBubbleShape : TTShape {
   CGFloat _radius;
   CGFloat _pointLocation;
@@ -29,7 +33,25 @@
 @property (nonatomic) CGFloat pointAngle;
 @property (nonatomic) CGSize  pointSize;
 
-+ (TTSpeechBubbleShape*)shapeWithRadius:(CGFloat)radius pointLocation:(CGFloat)pointLocation
-                             pointAngle:(CGFloat)pointAngle pointSize:(CGSize)pointSize;
+/**
+ * The shape that defines a rectangular shape with a pointer.
+ * Radius - number of pixels for the rounded corners
+ * pointLocation - location of the point where the top edge starts at 45, the right edge at 135,
+ *                 the bottom edge at 225 and the left edge at 315.
+ * pointAngle - not fgunctional yet. Make this equal to pointLocation in order to point it in the
+ * right direction.
+ * pointSize - the square in which the pointer will be defined, should be narrower or less high than
+ *             the shape minus the radiuses.
+ *
+ * Pointers are not placed on the rounded corners.
+ *
+ * pointSize should be less wide or high than the edge that it is placed on minus 2 * radius.
+ * radius should be smaller than the length of the edge / 2.
+ *
+ */
++ (TTSpeechBubbleShape*)shapeWithRadius:(CGFloat)radius
+                          pointLocation:(CGFloat)pointLocation
+                             pointAngle:(CGFloat)pointAngle
+                              pointSize:(CGSize)pointSize;
 
 @end

--- a/src/Three20Style/Sources/TTSpeechBubbleShape.m
+++ b/src/Three20Style/Sources/TTSpeechBubbleShape.m
@@ -197,30 +197,29 @@ static const CGFloat kInsetWidth = 5;
     CGPathMoveToPoint(path, nil, 0, fh-radius);
   }
 
+  // Use a custom pointLocation with a value between 315 and 405 instead of 0-45 and 315-360
+  // to ease calculations
+  CGFloat myPointLocation = _pointLocation;
+  if (myPointLocation >= 0 && myPointLocation < 45) {
+    myPointLocation += 360;
+  }
 
-  if ((_pointLocation >= 315 && _pointLocation < 360) ||
-      (_pointLocation >= 0 && _pointLocation < 45)) {
+  if (myPointLocation >= 315 && myPointLocation < 405) {
 
     // Compute extension of arrow
     CGFloat pw = _pointAngle >= 270 || _pointAngle <= 90 ? -_pointSize.width : _pointSize.width;
 
     // Compute location of arrow on line
     // Do not place the arrow on the arcs at the corner!
-    if (_pointLocation >= 315) {
-      pointY = fh - (((_pointLocation - 315) / 90) * (fh - 2 * radius - _pointSize.height) +
-                radius + floor(_pointSize.height/2));
-
-    } else {
-      pointY = fh - ((_pointLocation / 90) * (fh - 2 * radius - _pointSize.height) +
-                radius + floor(_pointSize.height/2));
-    }
+    pointY = fh - (((myPointLocation - 315) / 90) * (fh - 2 * radius - _pointSize.height) +
+                   radius + _pointSize.height/2);
 
     // Draw the lines, first to the arrow...
-    CGPathAddLineToPoint(path, nil, 0, pointY+floor(_pointSize.width/2));
+    CGPathAddLineToPoint(path, nil, 0, pointY+floor(_pointSize.height/2));
     // Then up to the point...
     CGPathAddLineToPoint(path, nil, pw, pointY);
     // And back again to the rectangle..
-    CGPathAddLineToPoint(path, nil, 0, pointY-floor(_pointSize.width/2));
+    CGPathAddLineToPoint(path, nil, 0, pointY-floor(_pointSize.height/2));
   }
 
   // Then continue the rest of the line

--- a/src/Three20Style/Sources/TTSpeechBubbleShape.m
+++ b/src/Three20Style/Sources/TTSpeechBubbleShape.m
@@ -66,24 +66,24 @@ static const CGFloat kInsetWidth = 5;
 
   if ((_pointLocation >= 0 && _pointLocation < 45)
       || (_pointLocation >= 315 && _pointLocation < 360)) {
-    if ((_pointAngle >= 270 && _pointAngle < 360) || (_pointAngle >= 0 && _pointAngle < 90)) {
+    if ((_pointAngle >= 270 && _pointAngle <= 360) || (_pointAngle >= 0 && _pointAngle <= 90)) {
       x += _pointSize.width;
       w -= _pointSize.width;
     }
 
   } else if (_pointLocation >= 45 && _pointLocation < 135) {
-    if (_pointAngle >= 0 && _pointAngle < 180) {
+    if (_pointAngle >= 0 && _pointAngle <= 180) {
       y += _pointSize.height;
       h -= _pointSize.height;
     }
 
   } else if (_pointLocation >= 135 && _pointLocation < 225) {
-    if (_pointAngle >= 90 && _pointAngle < 270) {
+    if (_pointAngle >= 90 && _pointAngle <= 270) {
       w -= _pointSize.width;
     }
 
-  } else if (_pointLocation >= 225 && _pointLocation <= 315) {
-    if (_pointAngle >= 180 && _pointAngle < 360) {
+  } else if (_pointLocation >= 225 && _pointLocation < 315) {
+    if (_pointAngle >= 180 && _pointAngle <= 360) {
       h -= _pointSize.height;
     }
   }
@@ -98,29 +98,31 @@ static const CGFloat kInsetWidth = 5;
   CGFloat fw = size.width;
   CGFloat fh = size.height;
   CGFloat pointX = 0;
+  CGFloat radius = RD(_radius);
 
   if (lightSource >= 0 && lightSource <= 90) {
     if (reset) {
-      CGPathMoveToPoint(path, nil, RD(_radius), 0);
+      CGPathMoveToPoint(path, nil, radius, 0);
     }
 
   } else {
     if (reset) {
-      CGPathMoveToPoint(path, nil, 0, RD(_radius));
+      CGPathMoveToPoint(path, nil, 0, radius);
     }
-    CGPathAddArcToPoint(path, nil, 0, 0, RD(_radius), 0, RD(_radius));
+    CGPathAddArcToPoint(path, nil, 0, 0, radius, 0, radius);
   }
 
-  if (_pointLocation >= 45 && _pointLocation <= 135) {
-    CGFloat ph = _pointAngle >= 0 && _pointAngle < 180 ? _pointSize.height : -_pointSize.height;
-    pointX = ((_pointLocation-45)/90) * fw;
+  if (_pointLocation >= 45 && _pointLocation < 135) {
+    CGFloat ph = _pointAngle >= 0 && _pointAngle <= 180 ? _pointSize.height : -_pointSize.height;
+    pointX = (((_pointLocation-45)/90) * (fw - 2 *radius - _pointSize.width) +
+              radius + floor(_pointSize.width/2));
 
     CGPathAddLineToPoint(path, nil, pointX-floor(_pointSize.width/2), 0);
     CGPathAddLineToPoint(path, nil, pointX, -ph);
     CGPathAddLineToPoint(path, nil, pointX+floor(_pointSize.width/2), 0);
   }
 
-  CGPathAddArcToPoint(path, nil, fw, 0, fw, RD(_radius), RD(_radius));
+  CGPathAddArcToPoint(path, nil, fw, 0, fw, radius, radius);
 }
 
 
@@ -129,12 +131,24 @@ static const CGFloat kInsetWidth = 5;
                reset:(BOOL)reset {
   CGFloat fw = size.width;
   CGFloat fh = size.height;
+  CGFloat pointY = 0;
+  CGFloat radius = RD(_radius);
 
   if (reset) {
-    CGPathMoveToPoint(path, nil, fw, RD(_radius));
+    CGPathMoveToPoint(path, nil, fw, radius);
   }
 
-  CGPathAddArcToPoint(path, nil, fw, fh, fw-RD(_radius), fh, RD(_radius));
+  if (_pointLocation >= 135 && _pointLocation < 225) {
+    CGFloat pw = _pointAngle >= 90 && _pointAngle <= 270 ? _pointSize.width : -_pointSize.width;
+    pointY = (((_pointLocation-135)/90) * (fh - 2 * radius - _pointSize.height) +
+              radius + floor(_pointSize.height/2));
+
+    CGPathAddLineToPoint(path, nil, fw, pointY-floor(_pointSize.height/2));
+    CGPathAddLineToPoint(path, nil, fw+pw, pointY);
+    CGPathAddLineToPoint(path, nil, fw, pointY+floor(_pointSize.height/2));
+  }
+
+  CGPathAddArcToPoint(path, nil, fw, fh, fw-radius, fh, radius);
 }
 
 
@@ -144,30 +158,31 @@ static const CGFloat kInsetWidth = 5;
   CGFloat fw = size.width;
   CGFloat fh = size.height;
   CGFloat pointX = 0;
+  CGFloat radius = RD(_radius);
 
   if (reset) {
-    CGPathMoveToPoint(path, nil, fw-RD(_radius), fh);
+    CGPathMoveToPoint(path, nil, fw-radius, fh);
   }
 
-  if (_pointLocation >= 225 && _pointLocation <= 315) {
+  if (_pointLocation >= 225 && _pointLocation < 315) {
     CGFloat ph;
 
-    if (_pointAngle >= 0 && _pointAngle < 180) {
+    if (_pointAngle >= 0 && _pointAngle <= 180) {
       ph = _pointSize.height;
 
     } else {
       ph = -_pointSize.height;
     }
 
-    pointX = fw - (((_pointLocation-225)/90) * fw);
-    CGPathAddArcToPoint(path, nil,  fw-RD(_radius), fh, floor(fw/2), fh, RD(_radius));
+    pointX = fw - (((_pointLocation-225)/90) * (fw - 2 *radius - _pointSize.width)
+                   + radius + floor(_pointSize.width/2));
+
     CGPathAddLineToPoint(path, nil, pointX+floor(_pointSize.width/2), fh);
     CGPathAddLineToPoint(path, nil, pointX, fh-ph);
     CGPathAddLineToPoint(path, nil, pointX-floor(_pointSize.width/2), fh);
-    CGPathAddLineToPoint(path, nil, RD(_radius), fh);
   }
 
-  CGPathAddArcToPoint(path, nil, 0, fh, 0, fh-RD(_radius), RD(_radius));
+  CGPathAddArcToPoint(path, nil, 0, fh, 0, fh-radius, radius);
 }
 
 
@@ -175,16 +190,45 @@ static const CGFloat kInsetWidth = 5;
 - (void)addLeftEdge:(CGSize)size lightSource:(NSInteger)lightSource toPath:(CGMutablePathRef)path
               reset:(BOOL)reset {
   CGFloat fh = size.height;
+  CGFloat pointY = 0;
+  CGFloat radius = RD(_radius);
 
   if (reset) {
-    CGPathMoveToPoint(path, nil, 0, fh-RD(_radius));
+    CGPathMoveToPoint(path, nil, 0, fh-radius);
   }
 
+
+  if ((_pointLocation >= 315 && _pointLocation < 360) ||
+      (_pointLocation >= 0 && _pointLocation < 45)) {
+
+    // Compute extension of arrow
+    CGFloat pw = _pointAngle >= 270 || _pointAngle <= 90 ? -_pointSize.width : _pointSize.width;
+
+    // Compute location of arrow on line
+    // Do not place the arrow on the arcs at the corner!
+    if (_pointLocation >= 315) {
+      pointY = fh - (((_pointLocation - 315) / 90) * (fh - 2 * radius - _pointSize.height) +
+                radius + floor(_pointSize.height/2));
+
+    } else {
+      pointY = fh - ((_pointLocation / 90) * (fh - 2 * radius - _pointSize.height) +
+                radius + floor(_pointSize.height/2));
+    }
+
+    // Draw the lines, first to the arrow...
+    CGPathAddLineToPoint(path, nil, 0, pointY+floor(_pointSize.width/2));
+    // Then up to the point...
+    CGPathAddLineToPoint(path, nil, pw, pointY);
+    // And back again to the rectangle..
+    CGPathAddLineToPoint(path, nil, 0, pointY-floor(_pointSize.width/2));
+  }
+
+  // Then continue the rest of the line
   if (lightSource >= 0 && lightSource <= 90) {
-    CGPathAddArcToPoint(path, nil, 0, 0, RD(_radius), 0, RD(_radius));
+    CGPathAddArcToPoint(path, nil, 0, 0, radius, 0, radius);
 
   } else {
-    CGPathAddLineToPoint(path, nil, 0, RD(_radius));
+    CGPathAddLineToPoint(path, nil, 0, radius);
   }
 }
 


### PR DESCRIPTION
Enabled arrows on left and right sides. Disabled arrows to be placed on corners; that looks ugly.

Three20 was unable to position the arrows on the speechbubbles on the side edges. This is corrected now.
In addition, positioning the arrow at 45 degrees would overlap the rounded corner. The arrow will now be placed right next to the rounded corner.

This has been mentioned on the forums in the past but proper code was never submitted.
