### PR TITLE
Fixed TTPostController's cancel logic to bring up the confirmation alert 

### DIFF
--- a/src/Three20UI/Sources/TTPostController.m
+++ b/src/Three20UI/Sources/TTPostController.m
@@ -518,7 +518,7 @@ static const CGFloat kMarginY = 6;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)cancel {
-  if (!TTIsStringWithAnyText(_textView.text)
+  if (TTIsStringWithAnyText(_textView.text)
       && !_textView.text.isWhitespaceAndNewlines
       && !(_defaultText && [_defaultText isEqualToString:_textView.text])) {
     UIAlertView* cancelAlertView = [[[UIAlertView alloc] initWithTitle:


### PR DESCRIPTION
When users click on the cancel button within a TTPostController, they are never presented with confirmation alert box (as suggested in the code). This 1-character patch fixes that problem.
