### PR TITLE
Restore views after memory warning: loading view, empty view, error view, table banner

### DIFF
--- a/src/Three20UI/Headers/TTTableViewController.h
+++ b/src/Three20UI/Headers/TTTableViewController.h
@@ -48,6 +48,8 @@
 
 /**
  * A view that is displayed as a banner at the bottom of the table view.
+ *
+ * This property should be set within viewDidLoad.
  */
 @property (nonatomic, retain) UIView* tableBannerView;
 
@@ -102,6 +104,8 @@
 
 /**
  * Sets the view that is displayed at the bottom of the table view with an optional animation.
+ *
+ * This method should be called within viewDidLoad.
  */
 - (void)setTableBannerView:(UIView*)tableBannerView animated:(BOOL)animated;
 

--- a/src/Three20UI/Headers/TTTableViewController.h
+++ b/src/Three20UI/Headers/TTTableViewController.h
@@ -48,8 +48,6 @@
 
 /**
  * A view that is displayed as a banner at the bottom of the table view.
- *
- * This property should be set within viewDidLoad.
  */
 @property (nonatomic, retain) UIView* tableBannerView;
 
@@ -104,8 +102,6 @@
 
 /**
  * Sets the view that is displayed at the bottom of the table view with an optional animation.
- *
- * This method should be called within viewDidLoad.
  */
 - (void)setTableBannerView:(UIView*)tableBannerView animated:(BOOL)animated;
 

--- a/src/Three20UI/Sources/TTModelViewController.m
+++ b/src/Three20UI/Sources/TTModelViewController.m
@@ -208,6 +208,7 @@
 - (void)didReceiveMemoryWarning {
   if (_hasViewAppeared && !_isViewAppearing) {
     [super didReceiveMemoryWarning];
+    [self resetViewStates];
     [self refresh];
 
   } else {

--- a/src/Three20UI/Sources/TTTableViewController.m
+++ b/src/Three20UI/Sources/TTTableViewController.m
@@ -225,6 +225,15 @@
 - (void)loadView {
   [super loadView];
   self.tableView;
+
+  // If this view was unloaded and is now being reloaded, and it was previously
+  // showing a table banner, then redisplay that banner now.
+  if (_tableBannerView) {
+    UIView* savedTableBannerView = [_tableBannerView retain];
+    [self setTableBannerView:nil animated:NO];
+    [self setTableBannerView:savedTableBannerView animated:NO];
+    [savedTableBannerView release];
+  }
 }
 
 
@@ -235,8 +244,6 @@
   _tableView.dataSource = nil;
   TT_RELEASE_SAFELY(_tableDelegate);
   TT_RELEASE_SAFELY(_tableView);
-  [_tableBannerView removeFromSuperview];
-  TT_RELEASE_SAFELY(_tableBannerView);
   [_tableOverlayView removeFromSuperview];
   TT_RELEASE_SAFELY(_tableOverlayView);
   [_loadingView removeFromSuperview];
@@ -249,6 +256,9 @@
   TT_RELEASE_SAFELY(_menuView);
   [_menuCell removeFromSuperview];
   TT_RELEASE_SAFELY(_menuCell);
+
+  // Do not release _tableBannerView, because we have no way to recreate it on demand if
+  // this view gets reloaded.
 }
 
 


### PR DESCRIPTION
When iOS issues a memory warning, that causes several problems in Three20 for any views that are offscreen at the time of the memory warning, if those views are brought back onscreen later:
- If a TTModelViewController subclass is showing an "empty view", that empty view will be gone.
- Same for an "error view"
- Same for a "loading view"
- If a TTTableViewController subclass is showing a banner, that banner will be gone.

To reproduce this, download https://github.com/mmorearty/Three20MemoryWarningBugs, and follow the instructions.

This pull request fixes the issues.

(I would have also tested the "overlay view" feature of TTTableViewController, but I couldn't figure out how to get it to work.)
