### PR TITLE
Fix tableView backgroundColor

### DIFF
--- a/src/Three20UI/Sources/TTTableViewController.m
+++ b/src/Three20UI/Sources/TTTableViewController.m
@@ -643,6 +643,11 @@
     ? TTSTYLEVAR(tableGroupedBackgroundColor)
     : TTSTYLEVAR(tablePlainBackgroundColor);
     if (backgroundColor) {
+      // With SDK 3.2 one needs to initialize the backgroundView before setting the backgroundColor
+      if ([_tableView respondsToSelector:@selector(backgroundView)]) {
+        [_tableView setBackgroundView:nil];
+        [_tableView setBackgroundView:[[[UIView alloc] init] autorelease]];
+      }
       _tableView.backgroundColor = backgroundColor;
       self.view.backgroundColor = backgroundColor;
     }


### PR DESCRIPTION
UITableView backgroundColor always gray on iPad. Since SDK 3.2 one needs to initialize the backgroundView before setting the backgroundColor. See also: http://stackoverflow.com/questions/2688007/uitableview-backgroundcolor-always-gray-on-ipad
