### PR TITLE
Fix URL navigation within modal view controller

### DIFF
--- a/src/Three20UINavigator/Sources/TTBaseNavigator.m
+++ b/src/Three20UINavigator/Sources/TTBaseNavigator.m
@@ -933,6 +933,16 @@ __attribute__((weak_import));
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (UIViewController*)topViewController {
   UIViewController* controller = _rootViewController;
+
+  // Modal view controllers are presented (and stacked) from TTRootViewController
+  // Use its modalViewController when available as start to find top view controller
+  if (self.rootContainer != nil) {
+    UIViewController *modalRootController = [self.rootContainer rootViewController];
+    if (modalRootController.modalViewController) {
+      controller = modalRootController.modalViewController;
+    }
+  }
+
   while (controller) {
     UIViewController* child = controller.popupViewController;
     if (!child || ![child canBeTopViewController]) {


### PR DESCRIPTION
This fixes the problem that URL navigation is not working correctly within a modal view, because it can not find the correct controller to navigate in. Modal views appear to be presented from the TTRootViewController, while _rootViewController does not point to the TTRootViewController. This solution checks for a modalViewController on TTRootViewController and uses that controller as root to find the topViewController. This means that when a modal view controller is visible, it will use that controller to navigate in.
