### PR TITLE
Modified TTURLRequest's "headers" property to lazy-initialize an instance of NSMutableDictionary on access.

### DIFF
--- a/src/Three20Network/Sources/TTURLRequest.m
+++ b/src/Three20Network/Sources/TTURLRequest.m
@@ -253,6 +253,15 @@ static NSString* kStringBoundary = @"3i2ndDfv2rTHiSisAbouNdArYfORhtTPEefj3q2f";
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
+- (NSMutableDictionary*)headers {
+  if (!_headers) {
+    _headers = [[NSMutableDictionary alloc] init];
+  }
+  return _headers;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
 - (NSData*)httpBody {
   if (_httpBody) {
     return _httpBody;


### PR DESCRIPTION
Since the `headers` property is marked as readonly and typed as `NSMutableDictionary`, one would expect to be able to modify its content without initializing it. This change ensures the property is always initialized with a copy of `NSMutableDictionary` when it's accessed.

If setting header variables should exclusively be done through `setValue:forHTTPHeaderField:`, the `headers` property should probably be typed as `NSDictionary` while keeping the `_headers` field typed as `NSMutableDictionary` so that users of this API would avoid setting header variables directly through the `headers` property.
