### PR TITLE
Updated TTRequestLoader's connectionDidFinishLoading: method to give TTURLResponse the chance to handle responses with invalid HTTP status code.

### DIFF
--- a/src/Three20Network/Headers/TTURLResponse.h
+++ b/src/Three20Network/Headers/TTURLResponse.h
@@ -45,4 +45,17 @@
 - (NSError*)request:(TTURLRequest*)request processResponse:(NSHTTPURLResponse*)response
             data:(id)data;
 
+@optional
+/**
+ * Processes the data from a unsuccessful request to construct a custom NSError object.
+ *
+ * @param  request    The request this response is bound to.
+ * @param  response   The response object, useful for getting the status code.
+ * @param  data       The data received from the TTURLRequest.
+ * @return NSError to construct for this response.
+ *
+ * @optional
+ */
+- (NSError*)request:(TTURLRequest*)request processErrorResponse:(NSHTTPURLResponse*)response
+               data:(id)data;
 @end

--- a/src/Three20Network/Sources/TTRequestLoader.m
+++ b/src/Three20Network/Sources/TTRequestLoader.m
@@ -240,7 +240,24 @@ static const NSInteger kLoadMaxRetries = 2;
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (NSError*)processResponse:(NSHTTPURLResponse*)response data:(id)data {
   for (TTURLRequest* request in _requests) {
-    NSError* error = [request.response request:request processResponse:response data:data];
+    NSError* error = nil;
+    // We need to accept valid HTTP status codes, not only 200.
+    if (!response
+        || (response.statusCode >= 200 && response.statusCode < 300)
+        || response.statusCode == 304) {
+      error = [request.response request:request processResponse:response data:data];
+    } else {
+      if ([request.response respondsToSelector:@selector(request:processErrorResponse:data:)]) {
+        error = [request.response request:request processErrorResponse:response data:data];
+      }
+      // Supply an NSError object if request.response's
+      // request:processErrorResponse:data: does not return one.
+      if (!error) {
+        TTDCONDITIONLOG(TTDFLAG_URLREQUEST, @"  FAILED LOADING (%d) %@", _response.statusCode, _urlPath);
+        NSDictionary* userInfo = [NSDictionary dictionaryWithObject:data forKey:kTTErrorResponseDataKey];
+        error = [NSError errorWithDomain:NSURLErrorDomain code:_response.statusCode userInfo:userInfo];
+      }
+    }
     if (error) {
       return error;
     }
@@ -366,24 +383,10 @@ static const NSInteger kLoadMaxRetries = 2;
 
   TTDCONDITIONLOG(TTDFLAG_ETAGS, @"Response status code: %d", _response.statusCode);
 
-  // We need to accept valid HTTP status codes, not only 200.
-  if (_response.statusCode >= 200 && _response.statusCode < 300) {
-    [_queue loader:self didLoadResponse:_response data:_responseData];
-
-  } else if (_response.statusCode == 304) {
+  if (_response.statusCode == 304) {
     [_queue loader:self didLoadUnmodifiedResponse:_response];
-
   } else {
-    TTDCONDITIONLOG(TTDFLAG_URLREQUEST, @"  FAILED LOADING (%d) %@",
-                    _response.statusCode, _urlPath);
-	  NSDictionary* userInfo = [NSDictionary dictionaryWithObject:_responseData forKey:kTTErrorResponseDataKey];
-	  NSError* error = [NSError errorWithDomain:NSURLErrorDomain code:_response.statusCode
-									   userInfo:userInfo];
-	  /*
-	   NSError* error = [NSError errorWithDomain:NSURLErrorDomain code:_response.statusCode
-	   userInfo:nil];
-	   */
-    [_queue loader:self didFailLoadWithError:error];
+    [_queue loader:self didLoadResponse:_response data:_responseData];
   }
 
   TT_RELEASE_SAFELY(_responseData);


### PR DESCRIPTION
This commit modifies `TTRequestLoader`'s `connectionDidFinishLoading:` to give `TTURLResponse`'s proposed optional method — `request:processErrorResponse:data:`'s — a chance at creating custom `NSError` objects for responses with invalid HTTP status code.

For example, when making Facebook Graph API calls with `TTURLRequest`, Facebook may respond with an HTTP status code 400 for a variety of reasons. Without this change, one would not be able to determine the specific type of error that happened (e.g. expired access token, missing access token, etc.) This change gives `TTURLResponse` the chance to extract JSON-encoded error message from the response's message body so that it can properly handle the error.
