### PR TITLE
Fix TTPhotoViewController's toolbar height calculation logic for iPad's landscape mode.

### DIFF
--- a/src/Three20UI/Sources/TTPhotoViewController.m
+++ b/src/Three20UI/Sources/TTPhotoViewController.m
@@ -235,12 +235,7 @@ static const NSInteger kActivityLabelTag          = 96;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)updateToolbarWithOrientation:(UIInterfaceOrientation)interfaceOrientation {
-  if (UIInterfaceOrientationIsPortrait(interfaceOrientation)) {
-    _toolbar.height = TT_TOOLBAR_HEIGHT;
-
-  } else {
-    _toolbar.height = TT_LANDSCAPE_TOOLBAR_HEIGHT+1;
-  }
+  _toolbar.height = TTToolbarHeight();
   _toolbar.top = self.view.height - _toolbar.height;
 }
 


### PR DESCRIPTION
When you use the TTPhotoViewController to view a captioned photo on the iPad in landscape mode, you'll notice a visible a gap between the caption and the toolbar. This pull request fixes that bug.
