### PR TITLE
Don't scroll during update in TTTableViewController.

### DIFF
--- a/src/Three20UI/Sources/TTTableViewController.m
+++ b/src/Three20UI/Sources/TTTableViewController.m
@@ -574,9 +574,6 @@
             TTDCONDITIONLOG(TTDFLAG_TABLEVIEWMODIFICATIONS, @"INSERTING ROW AT %@", newIndexPath);
             [_tableView insertRowsAtIndexPaths:[NSArray arrayWithObject:newIndexPath]
                               withRowAnimation:UITableViewRowAnimationTop];
-
-            [_tableView scrollToRowAtIndexPath:newIndexPath
-                              atScrollPosition:UITableViewScrollPositionNone animated:NO];
           }
           [self invalidateView];
 


### PR DESCRIPTION
In -model:didInsertObject:atIndexPath: of TTTableViewController, the
-scrollToRowAtIndexPath:atScrollPosition:animated: message was send
to the tableView whenever a new row was inserted. This is not going
to work if the new row was inserted as part of a larger change, i.e.
if -beginUpdates was called on the tableView and some new sections
were inserted prior to inserting the row.

In addition, scrolling to arbitrary rows without explicit control
from the App developer isn't good practice either, so just ditch
the scroll code all together.
