### PR TITLE
TTLauncherView: Update pager's currentPage value if scrollToItem gets called.

### DIFF
--- a/src/Three20UI/Sources/TTLauncherView.m
+++ b/src/Three20UI/Sources/TTLauncherView.m
@@ -917,6 +917,7 @@ static const NSInteger kDefaultColumnCount = 3;
     NSUInteger page = [path indexAtPosition:0];
     CGFloat x = page * _scrollView.width;
     [_scrollView setContentOffset:CGPointMake(x, 0) animated:animated];
+    [self updatePagerWithContentOffset:CGPointMake(x, 0)];
   }
 }
 

--- a/src/Three20UI/Sources/TTLauncherView.m
+++ b/src/Three20UI/Sources/TTLauncherView.m
@@ -740,6 +740,12 @@ static const NSInteger kDefaultColumnCount = 3;
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView {
+  [self updatePagerWithContentOffset:_scrollView.contentOffset];
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark -
 #pragma mark UIPageControlDelegate
@@ -917,7 +923,9 @@ static const NSInteger kDefaultColumnCount = 3;
     NSUInteger page = [path indexAtPosition:0];
     CGFloat x = page * _scrollView.width;
     [_scrollView setContentOffset:CGPointMake(x, 0) animated:animated];
-    [self updatePagerWithContentOffset:CGPointMake(x, 0)];
+    if (!animated) {
+      [self updatePagerWithContentOffset:CGPointMake(x, 0)];
+    }
   }
 }
 

--- a/src/Three20UI/Sources/TTLauncherView.m
+++ b/src/Three20UI/Sources/TTLauncherView.m
@@ -735,13 +735,13 @@ static const NSInteger kDefaultColumnCount = 3;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {
-  [self updatePagerWithContentOffset:_scrollView.contentOffset];
+  [self updatePagerWithContentOffset:scrollView.contentOffset];
 }
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView {
-  [self updatePagerWithContentOffset:_scrollView.contentOffset];
+  [self updatePagerWithContentOffset:scrollView.contentOffset];
 }
 
 


### PR DESCRIPTION
The pager's currentPage value is not updated if scrollToItem:animated: scrolls to another page. A simple additional line fixes that.
