### PR TITLE
Resubmitting pull request to development instead of master

### DIFF
--- a/src/Three20UI/Sources/TTPhotoView.m
+++ b/src/Three20UI/Sources/TTPhotoView.m
@@ -277,7 +277,16 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (BOOL)loadPreview:(BOOL)fromNetwork {
-  if (![self loadVersion:TTPhotoVersionLarge fromNetwork:NO]) {
+	BOOL keepTrying = YES;
+	// Trying to load the large image first causes scrolling to stall something
+	// fierce when using local images on older iPhones since the large image
+	// *always* starts to load in time for this first call to succeed. So we
+	// skip straight to attempting to load the small version unless we're loading
+	// off the network.
+	if (fromNetwork) {
+		keepTrying = [self loadVersion:TTPhotoVersionLarge fromNetwork:NO];
+	}
+	if (keepTrying) {
     if (![self loadVersion:TTPhotoVersionSmall fromNetwork:NO]) {
       if (![self loadVersion:TTPhotoVersionThumbnail fromNetwork:fromNetwork]) {
         return NO;


### PR DESCRIPTION
Hi John,

Sorry for the delayed response...here's my previous pull request (https://github.com/facebook/three20/pull/315) submitted to development instead of master. I've gone ahead and closed #315.

Cheers,
Chris

Fixed a problem that causes performance problems for scrollviews that use TTPhotoView with images stored on-device.
