### PR TITLE
Add support orientation for TTTabStrip

### DIFF
--- a/src/Three20UI/Sources/TTTabStrip.m
+++ b/src/Three20UI/Sources/TTTabStrip.m
@@ -45,6 +45,7 @@
     _scrollView.scrollsToTop = NO;
     _scrollView.showsVerticalScrollIndicator = NO;
     _scrollView.showsHorizontalScrollIndicator = NO;
+    _scrollView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
     [self addSubview:_scrollView];
 
     self.style = TTSTYLE(tabStrip);


### PR DESCRIPTION
For example.

CGRect applicationFrame = [UIScreen mainScreen].applicationFrame;
    _tabBar = [[[TTTabStrip alloc] initWithFrame:CGRectMake(0, 0, applicationFrame.size.width, 41)] autorelease];
    _tabBar.tabItems = [NSArray arrayWithObjects:
                         [[[TTTabItem alloc] initWithTitle:@"Item 1"] autorelease],
                         [[[TTTabItem alloc] initWithTitle:@"Item 2"] autorelease],
                         [[[TTTabItem alloc] initWithTitle:@"Item 3"] autorelease],
                         [[[TTTabItem alloc] initWithTitle:@"Item 4"] autorelease],
                         [[[TTTabItem alloc] initWithTitle:@"Item 5"] autorelease],
                         [[[TTTabItem alloc] initWithTitle:@"Item 6"] autorelease],
                         [[[TTTabItem alloc] initWithTitle:@"Item 7"] autorelease],
                         [[[TTTabItem alloc] initWithTitle:@"Item 8"] autorelease],
                         [[[TTTabItem alloc] initWithTitle:@"Item 9"] autorelease],
                         [[[TTTabItem alloc] initWithTitle:@"Item 10"] autorelease],
                         nil];
    _tabBar.autoresizingMask = UIViewAutoresizingFlexibleWidth;
    [self.view addSubview:_tabBar1];

It will has problem when change to landscape mode. Item's scroll view won't change width to fit the size.
