### PR TITLE
[UI] TTLauncherView persistent addition

### DIFF
--- a/samples/TTCatalog/Classes/LauncherViewTestController.m
+++ b/samples/TTCatalog/Classes/LauncherViewTestController.m
@@ -28,40 +28,44 @@
   _launcherView.backgroundColor = [UIColor blackColor];
   _launcherView.delegate = self;
   _launcherView.columnCount = 4;
-  _launcherView.pages = [NSArray arrayWithObjects:
-    [NSArray arrayWithObjects:
-      [[[TTLauncherItem alloc] initWithTitle:@"Button 1"
+  _launcherView.persistenceMode = TTLauncherPersistenceModeAll;
+  
+  if (![_launcherView restoreLauncherItems]) {
+    _launcherView.pages = [NSArray arrayWithObjects:
+      [NSArray arrayWithObjects:
+        [[[TTLauncherItem alloc] initWithTitle:@"Button 1"
                                image:@"bundle://Icon.png"
                                URL:nil canDelete:YES] autorelease],
-      [[[TTLauncherItem alloc] initWithTitle:@"Button 2"
+        [[[TTLauncherItem alloc] initWithTitle:@"Button 2"
                                image:@"bundle://Icon.png"
                                URL:nil canDelete:YES] autorelease],
-      [[[TTLauncherItem alloc] initWithTitle:@"Button 3"
+        [[[TTLauncherItem alloc] initWithTitle:@"Button 3"
                                image:@"bundle://Icon.png"
                                URL:@"fb://item3" canDelete:YES] autorelease],
-      [[[TTLauncherItem alloc] initWithTitle:@"Button 4"
+        [[[TTLauncherItem alloc] initWithTitle:@"Button 4"
                                image:@"bundle://Icon.png"
                                URL:@"fb://item4" canDelete:YES] autorelease],
-      [[[TTLauncherItem alloc] initWithTitle:@"Button 5"
+        [[[TTLauncherItem alloc] initWithTitle:@"Button 5"
                                image:@"bundle://Icon.png"
                                URL:@"fb://item5" canDelete:YES] autorelease],
-      [[[TTLauncherItem alloc] initWithTitle:@"Button 6"
+        [[[TTLauncherItem alloc] initWithTitle:@"Button 6"
                                image:@"bundle://Icon.png"
                                URL:@"fb://item6" canDelete:YES] autorelease],
-      [[[TTLauncherItem alloc] initWithTitle:@"Button 7"
+        [[[TTLauncherItem alloc] initWithTitle:@"Button 7"
                                image:@"bundle://Icon.png"
                                URL:@"fb://item7" canDelete:YES] autorelease],
-      nil],
-    [NSArray arrayWithObjects:
-      [[[TTLauncherItem alloc] initWithTitle:@"Button 8"
+        nil],
+      [NSArray arrayWithObjects:
+        [[[TTLauncherItem alloc] initWithTitle:@"Button 8"
                                image:@"bundle://Icon.png"
                                URL:nil canDelete:YES] autorelease],
-      [[[TTLauncherItem alloc] initWithTitle:@"Button 9"
+        [[[TTLauncherItem alloc] initWithTitle:@"Button 9"
                                image:@"bundle://Icon.png"
                                URL:nil canDelete:YES] autorelease],
-      nil],
-      nil
-    ];
+        nil],
+        nil
+      ];
+  }
   [self.view addSubview:_launcherView];
 
   TTLauncherItem* item = [_launcherView itemWithURL:@"fb://item3"];

--- a/src/Three20UI/Headers/TTLauncherPersistenceMode.h
+++ b/src/Three20UI/Headers/TTLauncherPersistenceMode.h
@@ -1,0 +1,21 @@
+//
+// Copyright 2009-2011 Facebook
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+typedef enum {
+  TTLauncherPersistenceModeNone,  // no persistence
+  TTLauncherPersistenceModeAll,   // persists all pages & buttons
+} TTLauncherPersistenceMode;
+

--- a/src/Three20UI/Headers/TTLauncherView.h
+++ b/src/Three20UI/Headers/TTLauncherView.h
@@ -17,6 +17,9 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
+// UI
+#import "Three20UI/TTLauncherPersistenceMode.h"
+
 @protocol TTLauncherViewDelegate;
 @class TTPageControl;
 @class TTLauncherButton;
@@ -51,6 +54,9 @@
   BOOL _springing;
   BOOL _editable;
 
+  NSString*                   _persistenceKey;
+  TTLauncherPersistenceMode   _persistenceMode;
+
   id<TTLauncherViewDelegate> _delegate;
 }
 
@@ -71,6 +77,20 @@
 @property (nonatomic, readonly) BOOL editing;
 @property (nonatomic, assign) BOOL editable;
 
+/**
+ * The key to use for storing persistence information.
+ *
+ * @default launcherViewPages
+ */
+@property (nonatomic, copy) NSString* persistenceKey;
+
+/**
+ * How buttons are automatically persisted on termination and restored on launch.
+ *
+ * @default TTLauncherPersistenceModeNone
+ */
+@property (nonatomic) TTLauncherPersistenceMode persistenceMode;
+
 - (void)addItem:(TTLauncherItem*)item animated:(BOOL)animated;
 
 - (void)removeItem:(TTLauncherItem*)item animated:(BOOL)animated;
@@ -84,6 +104,21 @@
 - (void)beginEditing;
 
 - (void)endEditing;
+
+/**
+ * Persists all pages & buttons to user defaults.
+ */
+- (void)persistLauncherItems;
+
+/**
+ * Restores all pages & button from user defaults and returns if sucess
+ */
+- (BOOL)restoreLauncherItems;
+
+/**
+ * Erases all data stored in user defaults.
+ */
+- (void)resetDefaults;
 
 /**
  * Dims the launcher view except for a transparent circle around the given item. The given text

--- a/src/Three20UI/Headers/Three20UI.h
+++ b/src/Three20UI/Headers/Three20UI.h
@@ -46,9 +46,11 @@
 #import "Three20UI/TTScrollViewDelegate.h"
 #import "Three20UI/TTScrollViewDataSource.h"
 
+// Launcher
 #import "Three20UI/TTLauncherView.h"
 #import "Three20UI/TTLauncherViewDelegate.h"
 #import "Three20UI/TTLauncherItem.h"
+#import "Three20UI/TTLauncherPersistenceMode.h"
 
 #import "Three20UI/TTLabel.h"
 #import "Three20UI/TTStyledTextLabel.h"

--- a/src/Three20UI/Sources/TTLauncherView.m
+++ b/src/Three20UI/Sources/TTLauncherView.m
@@ -23,6 +23,7 @@
 #import "Three20UI/TTPageControl.h"
 #import "Three20UI/UIViewAdditions.h"
 
+
 // UI (private)
 #import "Three20UI/private/TTLauncherScrollView.h"
 #import "Three20UI/private/TTLauncherHighlightView.h"
@@ -69,6 +70,8 @@ static const NSInteger kDefaultColumnCount = 3;
 @synthesize editing     = _editing;
 @synthesize delegate    = _delegate;
 @synthesize editable	= _editable;
+@synthesize persistenceMode           = _persistenceMode;
+@synthesize persistenceKey            = _persistenceKey;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (id)initWithFrame:(CGRect)frame {
@@ -99,6 +102,9 @@ static const NSInteger kDefaultColumnCount = 3;
     self.autoresizesSubviews = YES;
     self.columnCount = kDefaultColumnCount;
     self.editable = YES;
+    self.persistenceKey = @"launcherViewPages";
+    self.persistenceMode = TTLauncherPersistenceModeNone;
+
   }
 
   return self;
@@ -985,10 +991,49 @@ static const NSInteger kDefaultColumnCount = 3;
 
   [self layoutButtons];
 
+  if (self.persistenceMode == TTLauncherPersistenceModeAll) {
+    [self persistLauncherItems];
+  }
+
   if ([_delegate respondsToSelector:@selector(launcherViewDidEndEditing:)]) {
     [_delegate launcherViewDidEndEditing:self];
   }
 }
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)persistLauncherItems {
+  NSData* pagesData = [NSKeyedArchiver archivedDataWithRootObject:self.pages];
+  [[NSUserDefaults standardUserDefaults] setValue:pagesData forKey:self.persistenceKey];
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (BOOL)restoreLauncherItems {
+  if (self.persistenceMode == TTLauncherPersistenceModeAll) {
+    NSData* pagesData = [[NSUserDefaults standardUserDefaults] objectForKey:self.persistenceKey];
+
+    NSObject* pages;
+    if (pagesData!=nil) {
+      pages = [NSKeyedUnarchiver unarchiveObjectWithData:pagesData];
+    }
+
+    if (pagesData!=nil && pages!=nil && [pages isKindOfClass:[NSArray class]]) {
+      self.pages = (NSArray*)pages;
+      return YES;
+    }
+  }
+
+  return NO;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)resetDefaults {
+  NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
+
+  [defaults removeObjectForKey:_persistenceKey];
+  [defaults synchronize];
+}
+
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/Three20UI/Three20UI.xcodeproj/project.pbxproj
+++ b/src/Three20UI/Three20UI.xcodeproj/project.pbxproj
@@ -1707,9 +1707,7 @@
 			isa = PBXGroup;
 			children = (
 				6EE738A31184ADB400A35176 /* libThree20Network.a */,
-				6DB1E2AF13CA813200A72466 /* libThree20Network-Xcode3.2.5.a */,
 				6EE738A51184ADB400A35176 /* NetworkUnitTests.octest */,
-				6DB1E2B113CA813200A72466 /* NetworkUnitTests-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";

--- a/src/Three20UI/Three20UI.xcodeproj/project.pbxproj
+++ b/src/Three20UI/Three20UI.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		66F2E85712D426AF006FB485 /* TTTableFooterInfiniteScrollView.m in Sources */ = {isa = PBXBuildFile; fileRef = 66F2E85512D426AF006FB485 /* TTTableFooterInfiniteScrollView.m */; };
 		66F2E85F12D426DA006FB485 /* TTTableViewNetworkEnabledDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 66F2E85D12D426DA006FB485 /* TTTableViewNetworkEnabledDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66F2E86512D426EF006FB485 /* TTTableViewNetworkEnabledDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 66F2E86312D426EF006FB485 /* TTTableViewNetworkEnabledDelegate.m */; };
+		6DB1E37D13CA885B00A72466 /* TTLauncherPersistenceMode.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DB1E37C13CA885B00A72466 /* TTLauncherPersistenceMode.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6E60820111B0C31400C93CD4 /* TTNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E6081FF11B0C31400C93CD4 /* TTNavigationController.m */; };
 		6E60820311B0C32600C93CD4 /* TTNavigationController.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E60820211B0C32600C93CD4 /* TTNavigationController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6E6454741184D2CD00F08CB1 /* Three20UI.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E6454731184D2CD00F08CB1 /* Three20UI.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -443,6 +444,7 @@
 		66F2E85512D426AF006FB485 /* TTTableFooterInfiniteScrollView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TTTableFooterInfiniteScrollView.m; path = Sources/TTTableFooterInfiniteScrollView.m; sourceTree = "<group>"; };
 		66F2E85D12D426DA006FB485 /* TTTableViewNetworkEnabledDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TTTableViewNetworkEnabledDelegate.h; path = Headers/TTTableViewNetworkEnabledDelegate.h; sourceTree = "<group>"; };
 		66F2E86312D426EF006FB485 /* TTTableViewNetworkEnabledDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TTTableViewNetworkEnabledDelegate.m; path = Sources/TTTableViewNetworkEnabledDelegate.m; sourceTree = "<group>"; };
+		6DB1E37C13CA885B00A72466 /* TTLauncherPersistenceMode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TTLauncherPersistenceMode.h; path = Headers/TTLauncherPersistenceMode.h; sourceTree = "<group>"; };
 		6E6081FF11B0C31400C93CD4 /* TTNavigationController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TTNavigationController.m; path = Sources/TTNavigationController.m; sourceTree = "<group>"; };
 		6E60820211B0C32600C93CD4 /* TTNavigationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TTNavigationController.h; path = Headers/TTNavigationController.h; sourceTree = "<group>"; };
 		6E64543D1184BE1B00F08CB1 /* Project.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Project.xcconfig; path = Configurations/Project.xcconfig; sourceTree = "<group>"; };
@@ -1561,6 +1563,7 @@
 		6E64583E1184E26500F08CB1 /* Launcher */ = {
 			isa = PBXGroup;
 			children = (
+				6DB1E37C13CA885B00A72466 /* TTLauncherPersistenceMode.h */,
 				6E6454D61184D4C500F08CB1 /* TTLauncherView.h */,
 				6E6456121184D4DA00F08CB1 /* TTLauncherView.m */,
 				6E6454D71184D4C500F08CB1 /* TTLauncherViewDelegate.h */,
@@ -1704,7 +1707,9 @@
 			isa = PBXGroup;
 			children = (
 				6EE738A31184ADB400A35176 /* libThree20Network.a */,
+				6DB1E2AF13CA813200A72466 /* libThree20Network-Xcode3.2.5.a */,
 				6EE738A51184ADB400A35176 /* NetworkUnitTests.octest */,
+				6DB1E2B113CA813200A72466 /* NetworkUnitTests-Xcode3.2.5.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1859,6 +1864,7 @@
 				666E18F51294543F001C1D97 /* TTSplitViewController.h in Headers */,
 				66F2E85412D426A5006FB485 /* TTTableFooterInfiniteScrollView.h in Headers */,
 				66F2E85F12D426DA006FB485 /* TTTableViewNetworkEnabledDelegate.h in Headers */,
+				6DB1E37D13CA885B00A72466 /* TTLauncherPersistenceMode.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
This changeset allows TTLauncherView pages & buttons to be persistent in the same matter UIViewControllers are persistent in the TTBaseNavigator. It allows to save changes that were made in the TTLauncherView into NSUserDefaults automatically.

By default, persistence is disabled to keep the same functionality as it was:

```
   _launcherView.persistenceMode = TTLauncherPersistenceModeNone;
```

To enable persistent pages & items, it's enough to set the persistenceMode and the class will take care of the rest:

```
  _launcherView.persistenceMode = TTLauncherPersistenceModeAll;
```

There's also a resetDefaults function that removes the settings.

TTCategory sample app was also updated with the new feature.
