### PR TITLE
Fix bug where URLs were always parsed if line breaks were parsed

### DIFF
--- a/src/Three20Style/Headers/TTStyledTextParser.h
+++ b/src/Three20Style/Headers/TTStyledTextParser.h
@@ -44,5 +44,6 @@
 
 - (void)parseXHTML:(NSString*)html;
 - (void)parseText:(NSString*)string;
+- (void)parseLine:(NSString *)string;
 
 @end

--- a/src/Three20Style/Sources/TTStyledTextParser.m
+++ b/src/Three20Style/Sources/TTStyledTextParser.m
@@ -286,7 +286,7 @@
         // Find all text before the line break and parse it
         NSRange textRange = NSMakeRange(stringIndex, range.location - stringIndex);
         NSString* substr = [string substringWithRange:textRange];
-        [self parseURLs:substr];
+        [self parseLine:substr];
 
         // Add a line break node after the text
         TTStyledLineBreakNode* br = [[[TTStyledLineBreakNode alloc] init] autorelease];
@@ -297,19 +297,22 @@
       } else {
         // Find all text until the end of hte string and parse it
         NSString* substr = [string substringFromIndex:stringIndex];
-        [self parseURLs:substr];
+        [self parseLine:substr];
         break;
       }
     }
+  } else {
+    [self parseLine:string];
+  }
+}
 
-  } else if (_parseURLs) {
+- (void)parseLine:(NSString *)string {
+  if (_parseURLs) {
     [self parseURLs:string];
-
   } else {
     TTStyledTextNode* node = [[[TTStyledTextNode alloc] initWithText:string] autorelease];
     [self addNode:node];
   }
 }
-
 
 @end


### PR DESCRIPTION
Presently, if you try to parse some text with parseLineBreaks set to YES, the value of parseURLs will be ignored, and all URLs will be parsed. This commit fixes that logic by abstracting the operation of parsing a line into its own method, which is always sensitive to the value of parseURLs.
