### PR TITLE
[UI] iAd support for setTableBannerView

### DIFF
--- a/src/Three20UI/Headers/TTTableViewController.h
+++ b/src/Three20UI/Headers/TTTableViewController.h
@@ -28,8 +28,6 @@
   UIView*       _errorView;
   UIView*       _emptyView;
 
-  NSTimer*      _bannerTimer;
-
   UIView*           _menuView;
   UITableViewCell*  _menuCell;
 

--- a/src/Three20UI/Sources/TTTableViewController.m
+++ b/src/Three20UI/Sources/TTTableViewController.m
@@ -687,7 +687,6 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)setTableBannerView:(UIView*)tableBannerView animated:(BOOL)animated {
-  TT_INVALIDATE_TIMER(_bannerTimer);
   if (tableBannerView != _tableBannerView) {
     if (_tableBannerView) {
       if (animated) {
@@ -705,7 +704,6 @@
       self.tableView.contentInset = UIEdgeInsetsMake(0, 0, TTSTYLEVAR(tableBannerViewHeight), 0);
       self.tableView.scrollIndicatorInsets = self.tableView.contentInset;
       _tableBannerView.frame = [self rectForBannerView];
-      _tableBannerView.userInteractionEnabled = NO;
       _tableBannerView.autoresizingMask = (UIViewAutoresizingFlexibleWidth
                                            | UIViewAutoresizingFlexibleTopMargin);
       [self addSubviewOverTableView:_tableBannerView];


### PR DESCRIPTION
removed disabling the user interaction to allow Apple's iAds to be displayed & removed unused banner timer from TTTableViewController.

This will allow to pass an ADBannerView instead of TTImageView to [self setTableBannerView:banner animated:YES] function
