### PR TITLE
[UI] showBars shouldn't hide/show the status bar if it's initially hidden from the application plist settings

### DIFF
--- a/src/Three20UICommon/Sources/UIViewControllerAdditions.m
+++ b/src/Three20UICommon/Sources/UIViewControllerAdditions.m
@@ -299,16 +299,22 @@ TT_FIX_CATEGORY_BUG(UIViewControllerAdditions)
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)showBars:(BOOL)show animated:(BOOL)animated {
-#ifdef __IPHONE_3_2
-	if ([[UIApplication sharedApplication]
-       respondsToSelector:@selector(setStatusBarHidden:withAnimation:)])
-		[[UIApplication sharedApplication] setStatusBarHidden:!show
-                                            withAnimation:(animated
-                                                           ? UIStatusBarAnimationFade
-                                                           : UIStatusBarAnimationNone)];
-	else
-#endif
-		[[UIApplication sharedApplication] setStatusBarHidden:!show animated:animated];
+
+  BOOL statusBarHidden = [[[[NSBundle mainBundle] infoDictionary]
+                           objectForKey:@"UIStatusBarHidden"] intValue];
+
+  if (!statusBarHidden) {
+    #ifdef __IPHONE_3_2
+    if ([[UIApplication sharedApplication]
+         respondsToSelector:@selector(setStatusBarHidden:withAnimation:)])
+      [[UIApplication sharedApplication] setStatusBarHidden:!show
+                                              withAnimation:(animated
+                                                             ? UIStatusBarAnimationFade
+                                                             :UIStatusBarAnimationNone)];
+    else
+  #endif
+    [[UIApplication sharedApplication] setStatusBarHidden:!show animated:animated];
+  }
 
   if (animated) {
     [UIView beginAnimations:nil context:NULL];


### PR DESCRIPTION
when the status bar is initially hidden from the application plist settings, UIViewController showBars function shouldn't hide/show the status bar.

Declaring UIStatusBarHidden to be TRUE in the application plist file means the application is in full screen mode without the standard status bar. The showBars tries to show/hide the status bar right now and it's creating unexpected results, as the view layout is set to be full screen.

I had many issues with the UINavigationBar overlapping the status bar, and this pull should fix it as well.
