### PR TITLE
Added default image support to ttbutton

### DIFF
--- a/samples/TTCatalog/Classes/ButtonTestController.m
+++ b/samples/TTCatalog/Classes/ButtonTestController.m
@@ -78,6 +78,18 @@
   }
 }
 
+- (TTStyle*)remoteAvatarButton:(UIControlState)state {
+    if (state == UIControlStateHighlighted) {
+        return [TTSolidFillStyle styleWithColor:[UIColor whiteColor] next:nil];
+    } else {
+        return [TTImageStyle styleWithImageURL:nil
+                                  defaultImage:[UIImage imageNamed:@"defaultPerson.png"]
+                                   contentMode:UIViewContentModeCenter
+                                          size:CGSizeMake(50, 50)
+                                          next:nil];
+    }
+}
+
 @end
 
 @implementation ButtonTestController
@@ -142,6 +154,9 @@
   scrollView.delaysContentTouches = NO;
   self.view = scrollView;
 
+    TTButton* remoteAvatarButton = [TTButton buttonWithStyle:@"remoteAvatarButton:"];
+    [remoteAvatarButton setImage:@"url" forState:UIControlStateNormal];
+
   NSArray* buttons = [NSArray arrayWithObjects:
     [TTButton buttonWithStyle:@"toolbarButton:" title:@"Toolbar Button"],
     [TTButton buttonWithStyle:@"toolbarRoundButton:" title:@"Round Button"],
@@ -152,6 +167,7 @@
     [TTButton buttonWithStyle:@"blueToolbarButton:" title:@"Blue Button"],
     [TTButton buttonWithStyle:@"embossedButton:" title:@"Embossed Button"],
     [TTButton buttonWithStyle:@"dropButton:" title:@"Shadow Button"],
+    remoteAvatarButton,
     nil];
 
   for (TTButton* button in buttons) {

--- a/src/Three20UI/Sources/TTButtonContent.m
+++ b/src/Three20UI/Sources/TTButtonContent.m
@@ -16,6 +16,9 @@
 
 #import "Three20UI/private/TTButtonContent.h"
 
+// Style
+#import "Three20Style/TTImageStyle.h"
+
 // UI
 #import "Three20UI/TTImageViewDelegate.h"
 
@@ -149,6 +152,11 @@
       }
 
     } else {
+      TTImageStyle* imageStyle = [_style firstStyleOfClass:[TTImageStyle class]];
+      if (imageStyle && imageStyle.defaultImage) {
+        self.image = imageStyle.defaultImage;
+      }
+
       TTURLRequest* request = [TTURLRequest requestWithURL:_imageURL delegate:self];
       request.response = [[[TTURLImageResponse alloc] init] autorelease];
       [request send];


### PR DESCRIPTION
Following the same pattern for TTImageView. If the TTButton is loading a remote image, place a default image while that request is sent and leave the image in place in case the image request fails.
