### PR TITLE
Fix for Drag to Refresh HeaderView not Being Cleanup Up

### DIFF
--- a/src/Three20UI/Sources/TTTableViewDragRefreshDelegate.m
+++ b/src/Three20UI/Sources/TTTableViewDragRefreshDelegate.m
@@ -100,6 +100,7 @@ static const CGFloat kHeaderVisibleHeight = 60.0f;
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)dealloc {
   [_model.delegates removeObject:self];
+  [_headerView removeFromSuperview];
   TT_RELEASE_SAFELY(_headerView);
   TT_RELEASE_SAFELY(_model);
 


### PR DESCRIPTION
Removed headerView from table view header on dealloc to ensure the view is properly removed from the table.

This fixes issue #623
