### PR TITLE
Fixed over-release of JSON string in TTURLJSONResponse

### DIFF
--- a/src/extThree20JSON/Source/TTURLJSONResponse.m
+++ b/src/extThree20JSON/Source/TTURLJSONResponse.m
@@ -61,12 +61,11 @@
   NSError* err = nil;
   if ([data isKindOfClass:[NSData class]]) {
 #ifdef EXTJSON_SBJSON
-    NSString* json = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+    NSString* json = [[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] autorelease];
     // When there are newline characters in the JSON string, 
     // the error "Unescaped control character '0x9'" will be thrown. This removes those characters.
     json =  [json stringByTrimmingCharactersInSet:[NSCharacterSet newlineCharacterSet]]; 
     _rootObject = [[json JSONValue] retain];
-    TT_RELEASE_SAFELY(json);
     if (!_rootObject) {
       err = [NSError errorWithDomain:kTTExtJSONErrorDomain
                                 code:kTTExtJSONErrorCodeInvalidJSON


### PR DESCRIPTION
Local variable json was replaced by an autoreleased string, then
explicitly released, causing a crash when the main autorelease pool
drained.
