### PR TITLE
Three20/tt web controller actionsheet fix

### DIFF
--- a/src/Three20UI/Sources/TTWebController.m
+++ b/src/Three20UI/Sources/TTWebController.m
@@ -130,6 +130,13 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)shareAction {
+  if (nil != _actionSheet && [_actionSheet isVisible]) {
+    //should only happen on the iPad
+    assert(TTIsPad());
+    [_actionSheet dismissWithClickedButtonIndex:-1 animated:YES];
+    return;
+  }
+
   if (nil == _actionSheet) {
     _actionSheet = [[UIActionSheet alloc] initWithTitle:nil
                                                delegate:self
@@ -143,12 +150,7 @@
     }  else {
       [_actionSheet showInView: self.view];
     }
-
-  } else {
-    [_actionSheet dismissWithClickedButtonIndex:-1 animated:YES];
-    TT_RELEASE_SAFELY(_actionSheet);
   }
-
 }
 
 
@@ -399,6 +401,12 @@
   if (buttonIndex == 0) {
     [[UIApplication sharedApplication] openURL:self.URL];
   }
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)actionSheet:(UIActionSheet *)actionSheet didDismissWithButtonIndex:(NSInteger)buttonIndex {
+  TT_RELEASE_SAFELY(_actionSheet);
 }
 
 


### PR DESCRIPTION
[UI] fixed TTWebController's action sheet showed up only on every second touch

when the share button is touched the second time, the UIAlertView doesn't show up. This fix disables reuse of _actionSheet and releases it in UIAlertView's delegate

@rogchap brought this up in https://github.com/jverkoey/nimbus/pull/19
