### PR TITLE
added -navigator:didNotMatchURL to the TTNavigatorDelegate optional selec

### DIFF
--- a/src/Three20UINavigator/Headers/TTNavigatorDelegate.h
+++ b/src/Three20UINavigator/Headers/TTNavigatorDelegate.h
@@ -45,4 +45,12 @@
 - (void)navigator:(TTBaseNavigator*)navigator willOpenURL:(NSURL*)URL
  inViewController:(UIViewController*)controller;
 
+/**
+ * The URL was not routed to in the navigator's TTURLMap
+ *
+ * This delegate selector will be messaged only when the navigator fails to fina 
+ * a matching path in its URLMap routes.  
+ */
+- (void)navigator:(TTBaseNavigator*)navigator didNotMatchURL:(NSURL*)URL;
+
 @end

--- a/src/Three20UINavigator/Sources/TTBaseNavigator.m
+++ b/src/Three20UINavigator/Sources/TTBaseNavigator.m
@@ -536,6 +536,12 @@ __attribute__((weak_import));
     }
 
     [[UIApplication sharedApplication] openURL:theURL];
+  } else {
+      // no match found, controller was nil
+      if ([_delegate respondsToSelector:@selector(navigator:didNotMatchURL:)]) {
+          [_delegate navigator: self
+                didNotMatchURL: theURL];
+      }
   }
 
   return controller;


### PR DESCRIPTION
added -navigator:didNotMatchURL to the TTNavigatorDelegate optional selectors so that the delegate can respond to a path that wasn't in the TTURLMap.  Delegate selector will be called when mapped viewcontroller is nil and delegate responds to the selector

Having a delegate method the indicates the ttNavigator failed to match would be incredibly useful.  We're designing an app that has multiple sub navigation semantics and wanted to centralize and test navigation.  This is proving almost impossible using the UIView dependent navigator container infrastructure.  

I've added this selector and messaged it from the TTBaseNavigator when the controller resolves nil

thanks! 
