### PR TITLE
Allow the labels for TTTabGrid to be visible

### DIFF
--- a/src/Three20Style/Sources/TTDefaultStyleSheet.m
+++ b/src/Three20Style/Sources/TTDefaultStyleSheet.m
@@ -409,10 +409,9 @@
       [TTSolidFillStyle styleWithColor:RGBCOLOR(150, 168, 191) next:
       [TTInnerShadowStyle styleWithColor:RGBACOLOR(0,0,0,0.6) blur:3 offset:CGSizeMake(0, 0) next:
       [TTBoxStyle styleWithPadding:UIEdgeInsetsMake(11, 10, 9, 10) next:
-      [TTPartStyle styleWithName:@"image" style:[self tabGridTabImage:state] next:
       [TTTextStyle styleWithFont:[UIFont boldSystemFontOfSize:11]  color:RGBCOLOR(255, 255, 255)
                    minimumFontSize:8 shadowColor:RGBACOLOR(0,0,0,0.1) shadowOffset:CGSizeMake(-1,-1)
-                   next:nil]]]]]];
+                   next:nil]]]]];
 
   } else {
     return
@@ -422,10 +421,9 @@
                                        width:1
                                  lightSource:125 next:
       [TTBoxStyle styleWithPadding:UIEdgeInsetsMake(11, 10, 9, 10) next:
-      [TTPartStyle styleWithName:@"image" style:[self tabGridTabImage:state] next:
       [TTTextStyle styleWithFont:[UIFont boldSystemFontOfSize:11]  color:self.linkTextColor
                    minimumFontSize:8 shadowColor:[UIColor colorWithWhite:255 alpha:0.9]
-                   shadowOffset:CGSizeMake(0, -1) next:nil]]]]];
+                   shadowOffset:CGSizeMake(0, -1) next:nil]]]];
   }
 }
 


### PR DESCRIPTION
In TTCatalog if you look at the TabGrid in the Tabs section, none of the labels are visible. By removing TTPartStyle from the default style sheet, the labels become visible. There is an underlying problem with TTPartStyle when it's sent a CGSizeZero TTImageStyle. It's causing weirdness in TTButton's `drawRect:` method to flip out when doing math on `imageBoxStyle.margin.right`
There seems to be very little point in having TTPartStyle in there for now as it's returning an empty image with nil default and nil image. It seems to be a high power user feature.

This will close out :octocat: #131 until someone has time to go into TTStyle and deal with the funky math.
