### PR TITLE
Set TTTableMessageItemCell height dynamically based on its content

### DIFF
--- a/src/Three20UI/Sources/TTTableMessageItemCell.m
+++ b/src/Three20UI/Sources/TTTableMessageItemCell.m
@@ -87,8 +87,20 @@ static const CGFloat    kDefaultMessageImageHeight  = 34.0f;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 + (CGFloat)tableView:(UITableView*)tableView rowHeightForObject:(id)object {
-  // XXXjoe Compute height based on font sizes
-  return 90;
+  TTTableMessageItem* item = object;
+
+  CGFloat height = TTSTYLEVAR(tableFont).ttLineHeight + kTableCellVPadding*1.5;
+  if (item.caption) {
+    height += TTSTYLEVAR(font).ttLineHeight;
+  }
+  if (item.text) {
+    height += TTSTYLEVAR(font).ttLineHeight * kMessageTextLineCount;
+  }
+  if (item.imageURL) {
+    height = height > kDefaultMessageImageHeight ? height : kDefaultMessageImageHeight;
+  }
+
+  return height;
 }
 
 


### PR DESCRIPTION
Right now, the height of `TTTableMessageItemCell` is hard-coded to be 90 pixels. This usually works, but in my case, I didn't want to display a caption. This led to 15 pixels of whitespace at the bottom of every cell.

This implementation assumes there's a title, like other item cells. It checks if there's a caption and/or text and increases appropriately. It also checks if an image is present and overrides the height if necessary.

I chose to multiply `kTableCellVPadding` by 1.5 rather than 2 to not break existing uses of this cell. I think it also "looks" better being 90 pixels high, as opposed to 95.
