### PR TITLE
TTCurrentLocale() update

### DIFF
--- a/src/Three20Core/Sources/TTGlobalCoreLocale.m
+++ b/src/Three20Core/Sources/TTGlobalCoreLocale.m
@@ -22,8 +22,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 NSLocale* TTCurrentLocale() {
-  NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
-  NSArray* languages = [defaults objectForKey:@"AppleLanguages"];
+  NSArray* languages = [NSLocale preferredLanguages];
   if (languages.count > 0) {
     NSString* currentLanguage = [languages objectAtIndex:0];
     return [[[NSLocale alloc] initWithLocaleIdentifier:currentLanguage] autorelease];


### PR DESCRIPTION
use [NSLocale preferredLanguages] rather than the NSUserDefaults directly.
the preferredLanguages function is available since the 2.0 sdk, so no issues in backward compatibility 

see http://stackoverflow.com/questions/1522210/always-returns-en-us-not-users-current-language
