### PR TITLE
[UI] Adding TTTableSection

### DIFF
--- a/samples/TTCatalog/Classes/TableItemTestController.m
+++ b/samples/TTCatalog/Classes/TableItemTestController.m
@@ -21,8 +21,8 @@ static NSString* kLoremIpsum = @"Lorem ipsum dolor sit amet, consectetur adipisi
     self.title = @"Table Items";
     self.variableHeightRows = YES;
 
-    // Uncomment this to see how the table looks with the grouped style
-    //self.tableViewStyle = UITableViewStyleGrouped;
+    // comment this to see how the table looks with the standard style
+    self.tableViewStyle = UITableViewStyleGrouped;
 
     // Uncomment this to see how the table cells look against a custom background color
     //self.tableView.backgroundColor = [UIColor yellowColor];
@@ -37,9 +37,9 @@ static NSString* kLoremIpsum = @"Lorem ipsum dolor sit amet, consectetur adipisi
       @"Generic Items",
       [TTTableSettingsItem itemWithText:Three20Version caption:@"Three20 Version"
                                                      URL:@"tt://tableItemTest"],
-      @"Links and Buttons",
       [TTTableTextItem itemWithText:@"TTTableTextItem" URL:@"tt://tableItemTest"
                        accessoryURL:@"http://www.google.com"],
+      [TTTableSection sectionWithHeaderTitle:@"Links & Buttons" footerTitle:nil],
       [TTTableLink itemWithText:@"TTTableLink" URL:@"tt://tableItemTest"],
       [TTTableButton itemWithText:@"TTTableButton"],
       [TTTableCaptionItem itemWithText:@"TTTableCaptionItem" caption:@"caption"
@@ -50,7 +50,7 @@ static NSString* kLoremIpsum = @"Lorem ipsum dolor sit amet, consectetur adipisi
                           text:kLoremIpsum timestamp:[NSDate date] URL:@"tt://tableItemTest"],
       [TTTableMoreButton itemWithText:@"TTTableMoreButton"],
 
-      @"Images",
+      [TTTableSection sectionWithHeaderTitle:@"Images" footerTitle:@"Usage of images inside TTTableView"],
       [TTTableImageItem itemWithText:@"TTTableImageItem" imageURL:localImage
                         URL:@"tt://tableItemTest"],
       [TTTableRightImageItem itemWithText:@"TTTableRightImageItem" imageURL:localImage

--- a/src/Three20UI/Headers/TTTableSection.h
+++ b/src/Three20UI/Headers/TTTableSection.h
@@ -1,0 +1,31 @@
+//
+// Copyright 2009-2011 Facebook
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <UIKit/UIKit.h>
+
+
+@interface TTTableSection : NSObject {
+  NSString*     _headerTitle;
+  NSString*     _footerTitle;
+}
+
+@property (nonatomic, copy)   NSString* headerTitle;
+@property (nonatomic, copy)   NSString* footerTitle;
+
+
++ (id)sectionWithHeaderTitle:(NSString*)headerTitle footerTitle:(NSString*)footerTitle;
+
+@end

--- a/src/Three20UI/Headers/Three20UI.h
+++ b/src/Three20UI/Headers/Three20UI.h
@@ -90,6 +90,7 @@
 #import "Three20UI/TTListDataSource.h"
 #import "Three20UI/TTSectionedDataSource.h"
 #import "Three20UI/TTTableHeaderView.h"
+#import "Three20UI/TTTableSection.h"
 #import "Three20UI/TTTableFooterInfiniteScrollView.h"
 #import "Three20UI/TTTableHeaderDragRefreshView.h"
 #import "Three20UI/TTTableViewCell.h"

--- a/src/Three20UI/Sources/TTSectionedDataSource.m
+++ b/src/Three20UI/Sources/TTSectionedDataSource.m
@@ -18,6 +18,7 @@
 
 // UI
 #import "Three20UI/TTTableItem.h"
+#import "Three20UI/TTTableSection.h"
 
 // Core
 #import "Three20Core/TTCorePreprocessorMacros.h"
@@ -67,7 +68,8 @@
   va_list ap;
   va_start(ap, object);
   while (object) {
-    if ([object isKindOfClass:[NSString class]]) {
+    if ([object isKindOfClass:[NSString class]] ||
+        [object isKindOfClass:[TTTableSection class]]) {
       [sections addObject:object];
       section = [NSMutableArray array];
       [items addObject:section];
@@ -90,7 +92,8 @@
   va_list ap;
   va_start(ap, object);
   while (object) {
-    if ([object isKindOfClass:[NSString class]]) {
+    if ([object isKindOfClass:[NSString class]] ||
+        [object isKindOfClass:[TTTableSection class]]) {
       [sections addObject:object];
 
     } else {
@@ -137,7 +140,26 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section {
   if (_sections.count) {
-    return [_sections objectAtIndex:section];
+    if ([[_sections objectAtIndex:section] isKindOfClass:[TTTableSection class]]) {
+      TTTableSection* sectionInfo = [_sections objectAtIndex:section];
+      return sectionInfo.headerTitle;
+
+    } else {
+      return [_sections objectAtIndex:section];
+    }
+
+  } else {
+    return nil;
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section {
+  if (tableView.style==UITableViewStyleGrouped &&
+      _sections.count &&
+      [[_sections objectAtIndex:section] isKindOfClass:[TTTableSection class]]) {
+    TTTableSection* sectionInfo = [_sections objectAtIndex:section];
+    return sectionInfo.footerTitle;
 
   } else {
     return nil;

--- a/src/Three20UI/Sources/TTTableSection.m
+++ b/src/Three20UI/Sources/TTTableSection.m
@@ -1,0 +1,51 @@
+//
+// Copyright 2009-2011 Facebook
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "Three20UI/TTTableSection.h"
+
+// Core
+#import "Three20Core/TTCorePreprocessorMacros.h"
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////
+@implementation TTTableSection
+
+@synthesize headerTitle     = _headerTitle;
+@synthesize footerTitle  = _footerTitle;
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
++ (id)sectionWithHeaderTitle:(NSString*)headerTitle footerTitle:(NSString*)footerTitle {
+  TTTableSection* item = [[[self alloc] init] autorelease];
+  item.headerTitle = headerTitle;
+  item.footerTitle = footerTitle;
+  return item;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)dealloc {
+  TT_RELEASE_SAFELY(_headerTitle);
+  TT_RELEASE_SAFELY(_footerTitle);
+
+  [super dealloc];
+}
+
+
+@end
+

--- a/src/Three20UI/Three20UI.xcodeproj/project.pbxproj
+++ b/src/Three20UI/Three20UI.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		66F2E85712D426AF006FB485 /* TTTableFooterInfiniteScrollView.m in Sources */ = {isa = PBXBuildFile; fileRef = 66F2E85512D426AF006FB485 /* TTTableFooterInfiniteScrollView.m */; };
 		66F2E85F12D426DA006FB485 /* TTTableViewNetworkEnabledDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 66F2E85D12D426DA006FB485 /* TTTableViewNetworkEnabledDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66F2E86512D426EF006FB485 /* TTTableViewNetworkEnabledDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 66F2E86312D426EF006FB485 /* TTTableViewNetworkEnabledDelegate.m */; };
+		6D31FEDB14312683006C6B7F /* TTTableSection.h in Headers */ = {isa = PBXBuildFile; fileRef = 6D31FEDA14312683006C6B7F /* TTTableSection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6D31FEDD1431268C006C6B7F /* TTTableSection.m in Sources */ = {isa = PBXBuildFile; fileRef = 6D31FEDC1431268C006C6B7F /* TTTableSection.m */; };
 		6DB1E37D13CA885B00A72466 /* TTLauncherPersistenceMode.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DB1E37C13CA885B00A72466 /* TTLauncherPersistenceMode.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6DD20D35141D0C1B00916A4A /* TTTableSettingsItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DD20D34141D0C1B00916A4A /* TTTableSettingsItem.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6DD20D37141D0C2800916A4A /* TTTableSettingsItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DD20D36141D0C2800916A4A /* TTTableSettingsItem.m */; };
@@ -448,6 +450,8 @@
 		66F2E85512D426AF006FB485 /* TTTableFooterInfiniteScrollView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TTTableFooterInfiniteScrollView.m; path = Sources/TTTableFooterInfiniteScrollView.m; sourceTree = "<group>"; };
 		66F2E85D12D426DA006FB485 /* TTTableViewNetworkEnabledDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TTTableViewNetworkEnabledDelegate.h; path = Headers/TTTableViewNetworkEnabledDelegate.h; sourceTree = "<group>"; };
 		66F2E86312D426EF006FB485 /* TTTableViewNetworkEnabledDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TTTableViewNetworkEnabledDelegate.m; path = Sources/TTTableViewNetworkEnabledDelegate.m; sourceTree = "<group>"; };
+		6D31FEDA14312683006C6B7F /* TTTableSection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TTTableSection.h; path = Headers/TTTableSection.h; sourceTree = "<group>"; };
+		6D31FEDC1431268C006C6B7F /* TTTableSection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TTTableSection.m; path = Sources/TTTableSection.m; sourceTree = "<group>"; };
 		6DB1E37C13CA885B00A72466 /* TTLauncherPersistenceMode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TTLauncherPersistenceMode.h; path = Headers/TTLauncherPersistenceMode.h; sourceTree = "<group>"; };
 		6DD20D34141D0C1B00916A4A /* TTTableSettingsItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TTTableSettingsItem.h; path = Headers/TTTableSettingsItem.h; sourceTree = "<group>"; };
 		6DD20D36141D0C2800916A4A /* TTTableSettingsItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TTTableSettingsItem.m; path = Sources/TTTableSettingsItem.m; sourceTree = "<group>"; };
@@ -781,6 +785,15 @@
 				66ADCD9B1291AA7100855386 /* TTExtensionInfoController.m */,
 			);
 			name = Extensions;
+			sourceTree = "<group>";
+		};
+		6D31FED61431266E006C6B7F /* Table Section */ = {
+			isa = PBXGroup;
+			children = (
+				6D31FEDA14312683006C6B7F /* TTTableSection.h */,
+				6D31FEDC1431268C006C6B7F /* TTTableSection.m */,
+			);
+			name = "Table Section";
 			sourceTree = "<group>";
 		};
 		6E08B274118282F700DA1579 /* Tests */ = {
@@ -1294,6 +1307,7 @@
 		6E6458271184DF1E00F08CB1 /* Tables */ = {
 			isa = PBXGroup;
 			children = (
+				6D31FED61431266E006C6B7F /* Table Section */,
 				6E6458281184DF5F00F08CB1 /* Table Controller */,
 				6E6458291184DF6C00F08CB1 /* Table Delegate */,
 				6E64582C1184DFC500F08CB1 /* Table Data Source */,
@@ -1877,6 +1891,7 @@
 				6DB1E37D13CA885B00A72466 /* TTLauncherPersistenceMode.h in Headers */,
 				6DD20D35141D0C1B00916A4A /* TTTableSettingsItem.h in Headers */,
 				6DD20D3B141D0C4800916A4A /* TTTableSettingsItemCell.h in Headers */,
+				6D31FEDB14312683006C6B7F /* TTTableSection.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2239,6 +2254,7 @@
 				66F2E86512D426EF006FB485 /* TTTableViewNetworkEnabledDelegate.m in Sources */,
 				6DD20D37141D0C2800916A4A /* TTTableSettingsItem.m in Sources */,
 				6DD20D39141D0C3A00916A4A /* TTTableSettingsItemCell.m in Sources */,
+				6D31FEDD1431268C006C6B7F /* TTTableSection.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
This change adds the ability to have custom footer text in table view sections.

A `TTSectionedDataSource` section can be either a standard `NSString` or a `TTTableSection` object. The section object can be used to set both header & footer text (or any combination of the two). 

`TTTableSection` class has one helper function which is used create sections, similar to the behavior of `TTTableItem`:

`[TTTableSection sectionWithHeaderTitle:@"Header Text" footerTitle:@"Footer Text"]`

See the modified TTCatalog with some examples.
