### PR TITLE
iOS 3.1 compatibility changes

### DIFF
--- a/src/Three20UI/Sources/UITableViewAdditions.m
+++ b/src/Three20UI/Sources/UITableViewAdditions.m
@@ -24,6 +24,7 @@
 
 // UICommon
 #import "Three20UICommon/UIWindowAdditions.h"
+#import "Three20UICommon/TTGlobalUICommon.h"
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -53,7 +54,7 @@ TT_FIX_CATEGORY_BUG(UITableViewAdditions)
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (CGFloat)tableCellMargin {
   if (self.style == UITableViewStyleGrouped) {
-      if (([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad)) {
+      if (TTIsPad()) {
           return 45.0;
       }
       else {

--- a/src/Three20UINavigator/Headers/TTBaseNavigator.h
+++ b/src/Three20UINavigator/Headers/TTBaseNavigator.h
@@ -37,7 +37,7 @@
 
   UIViewController*           _rootViewController;
   NSMutableArray*             _delayedControllers;
-  UIPopoverController*        _popoverController;
+  id        _popoverController;
 
   NSString*                   _persistenceKey;
   TTNavigatorPersistenceMode  _persistenceMode;

--- a/src/Three20UINavigator/Sources/TTBaseNavigator.m
+++ b/src/Three20UINavigator/Sources/TTBaseNavigator.m
@@ -39,6 +39,7 @@
 #import "Three20Core/TTDebug.h"
 #import "Three20Core/TTDebugFlags.h"
 #import "Three20Core/NSDateAdditions.h"
+#import "Three20Core/TTAvailability.h"
 
 static TTBaseNavigator* gNavigator = nil;
 
@@ -344,8 +345,12 @@ __attribute__((weak_import));
     TT_RELEASE_SAFELY(_popoverController);
   }
 
-  _popoverController = [[UIPopoverController alloc] initWithContentViewController:controller];
-  _popoverController.delegate = self;
+  _popoverController =  [[TTUIPopoverControllerClass() alloc] init];
+  if (_popoverController != nil) {
+    [_popoverController setContentViewController:controller];
+    [_popoverController setDelegate:self];
+  }
+
   if (nil != sourceButton) {
     [_popoverController presentPopoverFromBarButtonItem: sourceButton
                                permittedArrowDirections: UIPopoverArrowDirectionAny


### PR DESCRIPTION
This request advances three20 iOS 3.1 compatibility (I'm using it in few of my apps)
- Using TTUIPopoverControllerClass() function to create the UIPopController 
- Fixed a direct call to userInterfaceIdiom, which was changed to TTIsPad()

The only issue left with three20 and iOS 3.1 compatibility is the TTSplitViewController controller, which can be easily removed (or replaced)
