### PR TITLE
Preventing occasional crash in TTURLRequestQueue :: createNSURLRequest:URL:

### DIFF
--- a/src/Three20Network/Sources/TTRequestLoader.m
+++ b/src/Three20Network/Sources/TTRequestLoader.m
@@ -120,6 +120,13 @@ static const NSInteger kLoadMaxRetries = 2;
   TTNetworkRequestStarted();
 
   TTURLRequest* request = _requests.count == 1 ? [_requests objectAtIndex:0] : nil;
+  
+  // there are situations where urlPath is somehow nil (therefore crashing in
+  // createNSURLRequest:URL:, even if we checked for non-blank values before 
+  // adding the request to the queue.
+  if (!request.urlPath.length)
+    [self cancel:request];
+
   NSURLRequest* URLRequest = [_queue createNSURLRequest:request URL:URL];
 
   _connection = [[NSURLConnection alloc] initWithRequest:URLRequest delegate:self];


### PR DESCRIPTION
The crash happens because we're attempting to call NSURL :: URLWithString: with a request.urlPath == nil.  I am aware that TTURLRequestQueue checks for blank urlPath's before queueing the request, but somehow this situation happens anyway. (Maybe during a memory warning cleanup?)

So I added a 2-liner sanity check to improve stability: this simply cancels the request in the case described above.
