### PR TITLE
Found a bug in a call to the TTDWARNING method

### DIFF
--- a/src/Three20UINavigator/Sources/TTURLNavigatorPattern.m
+++ b/src/Three20UINavigator/Sources/TTURLNavigatorPattern.m
@@ -487,7 +487,7 @@ static NSString* kUniversalURLPattern = @"*";
       returnValue = [self invoke:target withURL:URL query:query];
 
     } else {
-      TTDWARNING(@"No object created from URL:'%@' URL");
+      TTDWARNING(@"No object created from URL:'%@'", URL);
     }
     [target release];
   }


### PR DESCRIPTION
I found this bug while mapping the navigator to a URL that generates no objects. The call to the TTDWARNING method, made inside the TTURLNavigationPattern class, has no NSString\* parameters, even if it uses a "%@" tag inside. 

Fixed the call to the TTDWARNING method extracting the URL parameter from the string
