### PR TITLE
cache://

### DIFF
--- a/src/Three20Core/Headers/TTGlobalCorePaths.h
+++ b/src/Three20Core/Headers/TTGlobalCorePaths.h
@@ -27,6 +27,11 @@ BOOL TTIsBundleURL(NSString* URL);
 BOOL TTIsDocumentsURL(NSString* URL);
 
 /**
+ * @return YES if the URL begins with "caches://"
+ */
+BOOL TTIsCachesURL(NSString* URL);
+
+/**
  * Used by TTPathForBundleResource to construct the bundle path.
  *
  * Retains the given bundle.
@@ -53,3 +58,8 @@ NSString* TTPathForBundleResource(NSString* relativePath);
  * @return The documents path concatenated with the given relative path.
  */
 NSString* TTPathForDocumentsResource(NSString* relativePath);
+
+/**
+ * @return The caches path concatenated with the given relative path.
+ */
+NSString* TTPathForCachesResource(NSString* relativePath);

--- a/src/Three20Core/Headers/TTGlobalCorePaths.h
+++ b/src/Three20Core/Headers/TTGlobalCorePaths.h
@@ -27,7 +27,7 @@ BOOL TTIsBundleURL(NSString* URL);
 BOOL TTIsDocumentsURL(NSString* URL);
 
 /**
- * @return YES if the URL begins with "caches://"
+ * @return YES if the URL begins with "cache://"
  */
 BOOL TTIsCachesURL(NSString* URL);
 

--- a/src/Three20Core/Sources/TTGlobalCorePaths.m
+++ b/src/Three20Core/Sources/TTGlobalCorePaths.m
@@ -33,6 +33,12 @@ BOOL TTIsDocumentsURL(NSString* URL) {
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
+BOOL TTIsCachesURL(NSString* URL) {
+  return [URL hasPrefix:@"cache://"];
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
 void TTSetDefaultBundle(NSBundle* bundle) {
   [bundle retain];
   [globalBundle release];
@@ -63,3 +69,16 @@ NSString* TTPathForDocumentsResource(NSString* relativePath) {
   }
   return [documentsPath stringByAppendingPathComponent:relativePath];
 }
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+NSString* TTPathForCachesResource(NSString* relativePath) {
+  static NSString* cachesPath = nil;
+  if (nil == cachesPath) {
+    NSArray* dirs = NSSearchPathForDirectoriesInDomains(
+      NSCachesDirectory, NSUserDomainMask, YES);
+    cachesPath = [[dirs objectAtIndex:0] retain];
+  }
+  return [cachesPath stringByAppendingPathComponent:relativePath];
+}
+

--- a/src/Three20Network/Sources/TTURLCache.m
+++ b/src/Three20Network/Sources/TTURLCache.m
@@ -62,7 +62,7 @@ static NSMutableDictionary* gNamedCaches = nil;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (id)initWithName:(NSString*)name {
-	self = [super init];
+  self = [super init];
   if (self) {
     _name             = [name copy];
     _cachePath        = [[TTURLCache cachePathWithName:name] retain];
@@ -86,7 +86,7 @@ static NSMutableDictionary* gNamedCaches = nil;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (id)init {
-	self = [self initWithName:kDefaultCacheName];
+  self = [self initWithName:kDefaultCacheName];
   if (self) {
   }
 
@@ -255,6 +255,14 @@ static NSMutableDictionary* gNamedCaches = nil;
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
+- (BOOL)imageExistsFromCaches:(NSString*)URL {
+  NSString* path = TTPathForCachesResource([URL substringFromIndex:8]);
+  NSFileManager* fm = [NSFileManager defaultManager];
+  return [fm fileExistsAtPath:path];
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
 - (UIImage*)loadImageFromBundle:(NSString*)URL {
   NSString* path = TTPathForBundleResource([URL substringFromIndex:9]);
   return [UIImage imageWithContentsOfFile:path];
@@ -264,6 +272,13 @@ static NSMutableDictionary* gNamedCaches = nil;
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (UIImage*)loadImageFromDocuments:(NSString*)URL {
   NSString* path = TTPathForDocumentsResource([URL substringFromIndex:12]);
+  return [UIImage imageWithContentsOfFile:path];
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (UIImage*)loadImageFromCaches:(NSString*)URL {
+  NSString* path = TTPathForCachesResource([URL substringFromIndex:8]);
   return [UIImage imageWithContentsOfFile:path];
 }
 
@@ -456,6 +471,12 @@ static NSMutableDictionary* gNamedCaches = nil;
         hasImage = [self imageExistsFromDocuments:[TTURLCache doubleImageURLPath:URL]];
       }
 
+    } else if (TTIsCachesURL(URL)) {
+      hasImage = [self imageExistsFromCaches:URL];
+      if (!hasImage) {
+        hasImage = [self imageExistsFromCaches:[TTURLCache doubleImageURLPath:URL]];
+      }
+
     }
   }
 
@@ -480,6 +501,10 @@ static NSMutableDictionary* gNamedCaches = nil;
 
     } else if (TTIsDocumentsURL(URL)) {
       image = [self loadImageFromDocuments:URL];
+      [self storeImage:image forURL:URL];
+
+    } else if (TTIsCachesURL(URL)) {
+      image = [self loadImageFromCaches:URL];
       [self storeImage:image forURL:URL];
     }
   }


### PR DESCRIPTION
Hey guys

I just got an app rejected saying I was storing information in the /Documents folder that I should be storing in the /Library/Caches folder

From their rejection notice:
"For example, only content that the user creates using your app, e.g., documents, new files, edits, etc., may be stored in the /Documents directory - and backed up by iCloud. Other content that the user may use within the app cannot be stored in this directory; such content, e.g., preference files, database files, plists, etc., must be stored in the /Library/Caches directory."

So this is fine, I went to move the locations where my application stored files, but I then noticed I was displaying some of these files inside a TTPhotoViewController. I was previously using documents:// to access the files, and had no easy way to access them now they were in the /Library/Caches folder

So, I have added cache:// to the provided URL protocols. This could be a candidate for pulling into three20? If I should be doing this a different way, let me know.

Thanks!
