### PR TITLE
TTPhotoViewController & rightBarButtonItem

### DIFF
--- a/src/Three20UI/Headers/TTPhotoViewController.h
+++ b/src/Three20UI/Headers/TTPhotoViewController.h
@@ -114,4 +114,11 @@
  */
 - (void)showActivity:(NSString*)title;
 
+/**
+ * The right bar button item for the navigation controller.
+ * The default is a "Show all" button if the previous view controller
+ * is not a TTThumbsViewController
+ */
+- (UIBarButtonItem*)rightBarButtonItem;
+
 @end

--- a/src/Three20UI/Sources/TTPhotoViewController.m
+++ b/src/Three20UI/Sources/TTPhotoViewController.m
@@ -213,30 +213,34 @@ static const NSInteger kActivityLabelTag          = 96;
                   _centerPhotoIndex+1, _photoSource.numberOfPhotos];
   }
 
-  if (![self.ttPreviousViewController isKindOfClass:[TTThumbsViewController class]]) {
-    if (_photoSource.numberOfPhotos > 1) {
-      self.navigationItem.rightBarButtonItem =
-      [[[UIBarButtonItem alloc] initWithTitle:TTLocalizedString(@"See All",
-                                                                @"See all photo thumbnails")
-                                        style:UIBarButtonItemStyleBordered
-                                       target:self
-                                       action:@selector(showThumbnails)]
-       autorelease];
-
-    } else {
-      self.navigationItem.rightBarButtonItem = nil;
-    }
-
-  } else {
-    self.navigationItem.rightBarButtonItem = nil;
-  }
-
+  self.navigationItem.rightBarButtonItem = [self rightBarButtonItem];
   UIBarButtonItem* playButton = [_toolbar itemWithTag:1];
   playButton.enabled = _photoSource.numberOfPhotos > 1;
   _previousButton.enabled = _centerPhotoIndex > 0;
   _nextButton.enabled = _centerPhotoIndex >= 0 && _centerPhotoIndex < _photoSource.numberOfPhotos-1;
 }
 
+- (UIBarButtonItem*)rightBarButtonItem
+{
+    
+    if (![self.ttPreviousViewController isKindOfClass:[TTThumbsViewController class]]) {
+        if (_photoSource.numberOfPhotos > 1) {
+            return
+            [[[UIBarButtonItem alloc] initWithTitle:TTLocalizedString(@"See All",
+                                                                      @"See all photo thumbnails")
+                                              style:UIBarButtonItemStyleBordered
+                                             target:self
+                                             action:@selector(showThumbnails)]
+             autorelease];
+            
+        } else {
+            return nil;
+        }
+        
+    } else {
+        return nil;
+    } 
+}
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)updateToolbarWithOrientation:(UIInterfaceOrientation)interfaceOrientation {


### PR DESCRIPTION
I have an app where I implemented my own thumbnail view and the hard coded button that shows a TTThumbsViewController would only confuse people.  Any chance you could merge this in or create some other method to suppress it?
