### PR TITLE
Fixed incorrect control's width

### DIFF
--- a/src/Three20UI/Sources/TTTableControlCell.m
+++ b/src/Three20UI/Sources/TTTableControlCell.m
@@ -167,6 +167,7 @@ static const CGFloat kControlPadding = 8.0f;
 
     if ([TTTableControlCell shouldConsiderControlIntrinsicSize:_control]) {
       minX += contentWidth - _control.width;
+      contentWidth = _control.width;
     }
 
     // XXXjoe For some reason I need to re-add the control as a subview or else


### PR DESCRIPTION
When the control return `YES` in the method `shouldConsiderControlIntrinsicSize`, e.g. `UISwitch`, besides the position `x` should be set, the width also need to be updated.

You didn't observe any problem in the existing code since only the `UISwitch` is the candidate - it's width is fixed anyway, but when you extend to more controls, you will see the problem.
