### PR TITLE
bug for TTTabStrip

### DIFF
--- a/src/Three20UI/Headers/TTTabStrip.h
+++ b/src/Three20UI/Headers/TTTabStrip.h
@@ -17,7 +17,7 @@
 // UI
 #import "Three20UI/TTTabBar.h"
 
-@interface TTTabStrip : TTTabBar {
+@interface TTTabStrip : TTTabBar<UIScrollViewDelegate> {
 @private
   TTView*       _overflowLeft;
   TTView*       _overflowRight;

--- a/src/Three20UI/Sources/TTTabStrip.m
+++ b/src/Three20UI/Sources/TTTabStrip.m
@@ -47,6 +47,7 @@
     _scrollView.showsVerticalScrollIndicator = NO;
     _scrollView.showsHorizontalScrollIndicator = NO;
     _scrollView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+    _scrollView.delegate = self;
     [self addSubview:_scrollView];
 
     self.style = TTSTYLE(tabStrip);
@@ -164,5 +165,12 @@
 }
 
 
+///////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark -
+#pragma mark UIScrollViewDelegate
+-(void)scrollViewDidScroll:(UIScrollView *)scrollView {
+  [self updateOverflow];
+}
 @end
 


### PR DESCRIPTION
TTTabStrip's "updateOverflow" method not get call when scrolling on iOS5.0.1 real device.
