### PR TITLE
Additions to TTGlobalUICommon

### DIFF
--- a/src/Three20UICommon/Headers/TTGlobalUICommon.h
+++ b/src/Three20UICommon/Headers/TTGlobalUICommon.h
@@ -23,6 +23,11 @@
 float TTOSVersion();
 
 /**
+ * Checks if the run-time version of the OS is at least a certain version.
+ */
+BOOL TTRuntimeOSVersionIsAtLeast(float version);
+
+/**
  * Checks if the link-time version of the OS is at least a certain version.
  */
 BOOL TTOSVersionIsAtLeast(float version);

--- a/src/Three20UICommon/Headers/TTGlobalUICommon.h
+++ b/src/Three20UICommon/Headers/TTGlobalUICommon.h
@@ -38,6 +38,11 @@ BOOL TTIsKeyboardVisible();
 BOOL TTIsPhoneSupported();
 
 /**
+ * @return TRUE if the device supports backgrounding
+ */
+BOOL TTIsMultiTaskingSupported();
+
+/**
  * @return TRUE if the device is iPad.
  */
 BOOL TTIsPad();

--- a/src/Three20UICommon/Sources/TTGlobalUICommon.m
+++ b/src/Three20UICommon/Sources/TTGlobalUICommon.m
@@ -106,6 +106,15 @@ BOOL TTIsPhoneSupported() {
   return [deviceType isEqualToString:@"iPhone"];
 }
 
+///////////////////////////////////////////////////////////////////////////////////////////////////
+BOOL TTIsMultiTaskingSupported() {
+    UIDevice* device = [UIDevice currentDevice];
+    BOOL backgroundSupported = NO;
+    if ([device respondsToSelector:@selector(isMultitaskingSupported)]){
+         backgroundSupported = device.multitaskingSupported;
+    }
+    return backgroundSupported;
+}
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 BOOL TTIsPad() {

--- a/src/Three20UICommon/Sources/TTGlobalUICommon.m
+++ b/src/Three20UICommon/Sources/TTGlobalUICommon.m
@@ -54,6 +54,12 @@ BOOL TTOSVersionIsAtLeast(float version) {
   // Floating-point comparison is pretty bad, so let's cut it some slack with an epsilon.
   static const CGFloat kEpsilon = 0.0000001f;
 
+#ifdef __IPHONE_5_0
+  return 5.0 - version >= -kEpsilon;
+#endif
+#ifdef __IPHONE_4_3
+  return 4.3 - version >= -kEpsilon;
+#endif
 #ifdef __IPHONE_4_2
   return 4.2 - version >= -kEpsilon;
 #endif

--- a/src/Three20UICommon/Sources/TTGlobalUICommon.m
+++ b/src/Three20UICommon/Sources/TTGlobalUICommon.m
@@ -48,6 +48,13 @@ float TTOSVersion() {
   return [[[UIDevice currentDevice] systemVersion] floatValue];
 }
 
+///////////////////////////////////////////////////////////////////////////////////////////////////
+BOOL TTRuntimeOSVersionIsAtLeast(float version) {
+
+    static const CGFloat kEpsilon = 0.0000001f;
+    return TTOSVersion() - version > -kEpsilon;
+}
+
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 BOOL TTOSVersionIsAtLeast(float version) {


### PR DESCRIPTION
1) Added support for detecting iOS 5.0 and 4.3 in TTOSVersionIsAtleast() method

2) Added method IsMultitaskingSupported to check if multitasking is supported

3) Added methos TTRuntimeOSVersionIsAtleast which checks for the OS version at runtime.(useful when say iOS SDK 5.0 compiles apps are run on iOS 4)
