### PR TITLE
Appledoc API Documentation 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ src/Three20UI/*.h
 extensions/
 
 *.pyc
+Docs

--- a/README.mdown
+++ b/README.mdown
@@ -21,6 +21,18 @@ If you would like to ask any questions regarding Three20, please check out any o
 * [Three20 Mailing List][]
 * [Three20 Tagged Questions on StackOverflow][]
 
+Documentation
+==============================
+
+You can access Three20 API documentation in several ways:
+
+1. Online: http://facebook.github.com/three20/api
+1. Within Xcode: 
+    1. Open your Xcode Preferences (`⌘,`) and switch to Documentation tab. 
+    1. Click the `+` button
+    1. Add the Three20 doc set feed: `feed://facebook.github.com/three20/api/com.facebook.Three20.atom`
+1. Generate the documentation from the project repository with the `src/scripts/docs.py` script
+
 Adding Three20 to your project
 ==============================
 

--- a/src/Three20UI/Headers/TTLauncherPersistenceMode.h
+++ b/src/Three20UI/Headers/TTLauncherPersistenceMode.h
@@ -16,6 +16,6 @@
 
 typedef enum {
   TTLauncherPersistenceModeNone,  // no persistence
-  TTLauncherPersistenceModeAll,   // persists all pages & buttons
+  TTLauncherPersistenceModeAll,   // persists all pages and buttons
 } TTLauncherPersistenceMode;
 

--- a/src/Three20UI/Headers/TTLauncherView.h
+++ b/src/Three20UI/Headers/TTLauncherView.h
@@ -106,12 +106,12 @@
 - (void)endEditing;
 
 /**
- * Persists all pages & buttons to user defaults.
+ * Persists all pages &amp; buttons to user defaults.
  */
 - (void)persistLauncherItems;
 
 /**
- * Restores all pages & button from user defaults and returns if sucess
+ * Restores all pages &amp; button from user defaults and returns if sucess
  */
 - (BOOL)restoreLauncherItems;
 

--- a/src/scripts/docs.py
+++ b/src/scripts/docs.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python
+# encoding: utf-8
+"""
+docs.py
+
+Created by Jeff Verkoeyen on 2010-10-18.
+Copyright 2009-2010 Facebook
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import logging
+import re
+import os
+import sys
+import shutil
+import errno
+import git
+
+# Three20 Python Objects
+import Paths
+
+from optparse import OptionParser
+
+def generate_appledoc(version):
+	logging.info("Generating appledoc")
+		
+	os.system("appledoc " + 
+              "--project-name Three20 " +
+              "--project-company \"Facebook\" " + 
+              "--company-id=com.facebook " + 
+              "--output Docs/ " + 
+              "--project-version " + version + " " + 
+              "--ignore .m --ignore Vendors --ignore UnitTests " + 
+              "--keep-undocumented-objects " + 
+              "--keep-undocumented-members " + 
+              "--warn-undocumented-object " + 
+              "--warn-undocumented-member " +
+              "--warn-empty-description " + 
+              "--warn-unknown-directive " + 
+              "--warn-invalid-crossref " +
+              "--warn-missing-arg " + 
+              "--keep-intermediate-files " +
+              "--docset-feed-name \"Three20 " + version + " Documentation\" " +
+              "--docset-feed-url http://facebook.github.com/three20/api/%DOCSETATOMFILENAME " + 
+              "--docset-package-url http://facebook.github.com/three20/api/%DOCSETPACKAGEFILENAME " + 
+              "--publish-docset " + 
+              "--verbose 5 src/")
+
+def publish_ghpages(version):
+		
+	logging.info("Cloning and checking out gh-pages")
+	os.system("git clone git@github.com:facebook/three20.git Docs/gh-pages")
+	os.system("cd Docs/gh-pages && git pull")
+	os.system("cd Docs/gh-pages && git checkout gh-pages")
+			
+	logging.info("Copying docset into gh-pages folder")
+		
+	os.system("cp -r -f Docs/html/* Docs/gh-pages/api")
+	os.system("cp -r -f Docs/publish/ Docs/gh-pages/api")
+			
+	logging.info("Committing new docs")
+	os.system("cd Docs/gh-pages && git add -A .")
+	os.system("cd Docs/gh-pages && git commit -am  \"Three20 " + version + " Documentation\"")
+	os.system("cd Docs/gh-pages && git push origin gh-pages")
+			
+
+def main():
+	usage = '''%prog [options]
+
+
+The Three20 Appledoc Generator Script.
+Use this script to generate appledoc
+--generate will generate the docs
+--publish will publish the new docs into the three20's gh-pages branch
+
+EXAMPLES:
+
+    Most common use case:
+    > %prog --version 1.0.10-dev --generate
+    
+'''
+	parser = OptionParser(usage = usage)
+	
+	parser.add_option("-o", "--generate", dest="generate",
+	                  help="Generate appledoc",
+	                  action="store_true")
+
+	parser.add_option("-p", "--publish", dest="publish",
+	                  help="publish gh-pages",
+	                  action="store_true")
+	
+	parser.add_option("-v", "--version", dest="version",
+	                  help="Project version")
+
+	parser.add_option("", "--verbose", dest="verbose",
+	                  help="Display verbose output",
+	                  action="store_true")
+  
+	(options, args) = parser.parse_args()
+
+	if options.verbose:
+		log_level = logging.INFO
+	else:
+		log_level = logging.WARNING
+        
+	logging.basicConfig(level=log_level)
+
+	did_anything = False
+
+	if options.generate:
+		did_anything = True
+
+		generate_appledoc(options.version)
+
+	if options.publish:
+		did_anything = True
+		publish_ghpages(options.version)
+
+	if not did_anything:
+		parser.print_help()
+
+
+if __name__ == "__main__":
+	sys.exit(main())


### PR DESCRIPTION
this pull request propose is to replace http://api.three20.info/ with an appledoc api docs hosted on github pages.

The docs.py script generates an appledoc doc set (which can be imported into xcode) and a html version of the api docs. the script also generates a gh-pages subfolder which can be pushed into the gh-pages branch, as a part of the release process.

To generate the API docs using appledoc, use the docs.py, for example:

`python src/scripts/docs.py --version 1.0.10-dev --generate`

After each release, we should generate & publish the API. the docs.py script will handle everything (clone, update the docs, and push back to to the gh-pages branch):

`python src/scripts/docs.py --version 1.0.10--generate --publish`

this pull request doesn't include the appledoc's binary (see discussion in #737)
