### PR TITLE
iOS 5 ipad compatibility issues

### DIFF
--- a/src/Three20UI/Sources/TTTableViewController.m
+++ b/src/Three20UI/Sources/TTTableViewController.m
@@ -914,7 +914,7 @@
   if ([object respondsToSelector:@selector(URLValue)]) {
     NSString* URL = [object URLValue];
     if (URL) {
-      TTOpenURLFromView(URL, self.view);
+      TTOpenURLFromView(URL, self.tableView);
     }
   }
 }

--- a/src/Three20UICommon/Sources/UIViewControllerAdditions.m
+++ b/src/Three20UICommon/Sources/UIViewControllerAdditions.m
@@ -154,6 +154,9 @@ TT_FIX_CATEGORY_BUG(UIViewControllerAdditions)
   if (nil != parent) {
     return parent;
 
+  } else if ([self respondsToSelector:@selector(presentingViewController)]) {
+    return [self presentingViewController];
+
   } else {
     NSString* key = [NSString stringWithFormat:@"%d", self.hash];
     return [gSuperControllers objectForKey:key];

--- a/src/Three20UINavigator/Headers/TTBaseNavigationController.h
+++ b/src/Three20UINavigator/Headers/TTBaseNavigationController.h
@@ -25,11 +25,13 @@
 
 }
 
-/**
- * TODO: Move this to a private category header.
- */
+
 - (void)pushAnimationDidStop;
 
+/**
+ * Pushes a view controller onto the receiver’s stack with a transition other than the
+ * standard sliding animation.
+ */
 - (void)pushViewController: (UIViewController*)controller
     animatedWithTransition: (UIViewAnimationTransition)transition;
 

--- a/src/Three20UINavigator/Headers/TTBaseNavigator.h
+++ b/src/Three20UINavigator/Headers/TTBaseNavigator.h
@@ -28,16 +28,14 @@
 /**
  * A URL-based navigation system with built-in persistence.
  */
-@interface TTBaseNavigator : NSObject <
-  UIPopoverControllerDelegate
-> {
+@interface TTBaseNavigator : NSObject <UIPopoverControllerDelegate> {
   TTURLMap*                   _URLMap;
 
   UIWindow*                   _window;
 
   UIViewController*           _rootViewController;
   NSMutableArray*             _delayedControllers;
-  id        _popoverController;
+  id                          _popoverController;
 
   NSString*                   _persistenceKey;
   TTNavigatorPersistenceMode  _persistenceMode;
@@ -222,8 +220,9 @@
  *
  * @return The view controller mapped to URL.
  */
-- (UIViewController*)viewControllerForURL:(NSString*)URL query:(NSDictionary*)query
-                                  pattern:(TTURLPattern**)pattern;
+- (UIViewController*)viewControllerForURL: (NSString*)URL
+                                    query: (NSDictionary*)query
+                                  pattern: (TTURLPattern**)pattern;
 
 /**
  * Tells the navigator to delay heavy operations.

--- a/src/Three20UINavigator/Headers/TTNavigatorDelegate.h
+++ b/src/Three20UINavigator/Headers/TTNavigatorDelegate.h
@@ -42,7 +42,8 @@
  *
  * If the controller argument is nil, the URL is going to be opened externally.
  */
-- (void)navigator:(TTBaseNavigator*)navigator willOpenURL:(NSURL*)URL
- inViewController:(UIViewController*)controller;
+- (void)navigator: (TTBaseNavigator*)navigator
+      willOpenURL: (NSURL*)URL
+ inViewController: (UIViewController*)controller;
 
 @end

--- a/src/Three20UINavigator/Headers/Three20UINavigator.h
+++ b/src/Three20UINavigator/Headers/Three20UINavigator.h
@@ -14,8 +14,9 @@
 // limitations under the License.
 //
 
-#import "Three20UINavigator/TTGlobalNavigatorMetrics.h"
+// Navigator
 
+#import "Three20UINavigator/TTGlobalNavigatorMetrics.h"
 #import "Three20UINavigator/TTURLObject.h"
 
 // - View Controllers

--- a/src/Three20UINavigator/Sources/TTBaseNavigator.m
+++ b/src/Three20UINavigator/Sources/TTBaseNavigator.m
@@ -141,13 +141,20 @@ __attribute__((weak_import));
 
   for (controller = view.viewController;
        nil != controller;
-       controller = controller.parentViewController) {
+       controller = controller.superController) {
     if ([controller conformsToProtocol:@protocol(TTNavigatorRootContainer)]) {
       container = (id<TTNavigatorRootContainer>)controller;
       break;
     }
 
     childController = controller;
+  }
+
+  if (container==nil) {
+    controller = [TTBaseNavigator globalNavigator].visibleViewController;
+    if ([controller conformsToProtocol:@protocol(TTNavigatorRootContainer)]) {
+      container = (id<TTNavigatorRootContainer>)controller;
+    }
   }
 
   TTBaseNavigator* navigator = [container getNavigatorForController:childController];

--- a/src/Three20UINavigator/Sources/TTBaseNavigator.m
+++ b/src/Three20UINavigator/Sources/TTBaseNavigator.m
@@ -889,12 +889,20 @@ __attribute__((weak_import));
   }
   [controller persistNavigationPath:path];
 
-  if (controller.modalViewController
-      && controller.modalViewController.parentViewController == controller) {
-    [self persistController:controller.modalViewController path:path];
+  UIViewController *modalController = controller.modalViewController;
+  if (modalController) {
+    UIViewController *parentViewController = [modalController
+                                              respondsToSelector:
+                                              @selector(presentingViewController)]
+    ? [modalController performSelector:@selector(presentingViewController)]
+    : [modalController parentViewController];
 
-  } else if (controller.popupViewController
-             && controller.popupViewController.superController == controller) {
+    if (parentViewController == controller) {
+      [self persistController:controller.modalViewController path:path];
+    }
+
+  } else if (controller.popupViewController &&
+             controller.popupViewController.superController == controller) {
     [self persistController:controller.popupViewController path:path];
   }
 }


### PR DESCRIPTION
 this pull request includes some changes to TTBaseController which solves the issues with UIPopViewController & TTSplitViewController under iOS 5.

The parentViewController function role was under with iOS 5 (http://omegadelta.net/2011/11/04/oh-my-god-they-killed-parentviewcontroller/) which caused issues with TTSplitViewController when the secondary view controller is displayed as a popup view controller.

closes #713
