### PR TITLE
Fix scrollview offset restore

### DIFF
--- a/src/Three20UI/Sources/TTTableViewController.m
+++ b/src/Three20UI/Sources/TTTableViewController.m
@@ -327,7 +327,8 @@
 - (void)restoreView:(NSDictionary*)state {
   CGFloat scrollY = [[state objectForKey:@"scrollOffsetY"] floatValue];
   if (scrollY) {
-    CGFloat maxY = _tableView.contentSize.height - _tableView.height;
+    //set to 0 if contentSize is smaller than the tableView.height
+    CGFloat maxY = MAX(0, _tableView.contentSize.height - _tableView.height);
     if (scrollY <= maxY) {
       _tableView.contentOffset = CGPointMake(0, scrollY);
 


### PR DESCRIPTION
when restoring the tableView offset, the maximum offset
can be a number < 0, if the contentSize doesn't fill the
whole tableview. If that's the case, set the maximum scrollOffset
to 0.
