### PR TITLE
Safeguard against UITabBarController selecting  a controller not in the tab bar

### DIFF
--- a/src/Three20UI/Sources/UITabBarControllerAdditions.m
+++ b/src/Three20UI/Sources/UITabBarControllerAdditions.m
@@ -89,7 +89,9 @@ TT_FIX_CATEGORY_BUG(UITabBarControllerAdditions)
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)bringControllerToFront:(UIViewController*)controller animated:(BOOL)animated {
-  self.selectedViewController = controller;
+  if ([self.viewControllers containsObject:controller]) {
+    self.selectedViewController = controller;
+  }
 }
 
 


### PR DESCRIPTION
Apple Docs states that only controllers in -[UITabBarController viewControllers] can be set as the -selectedViewController.

If for some reasons iOS messes up the view controllers hierarchy (it happens), setting an unknown view controller will fail (and present a blank screen). This fix avoids that.
