### PR TITLE
TTTableView shadow crash fix

### DIFF
--- a/src/Three20UI/Sources/TTTableView.m
+++ b/src/Three20UI/Sources/TTTableView.m
@@ -258,7 +258,9 @@ static const CGFloat kCancelHighlightThreshold = 4.0f;
 
   } else if (![[self.layer.sublayers objectAtIndex:0] isEqual:_originShadow]) {
     [_originShadow removeFromSuperlayer];
-    [self.layer insertSublayer:_originShadow atIndex:0];
+
+    _originShadow = [self shadowAsInverse:NO];
+   [self.layer insertSublayer:_originShadow atIndex:0];
   }
 
   [CATransaction begin];


### PR DESCRIPTION
`TTTableView` with shadows (`self.showTableShadows = YES`) will cause a crash under iOS 5 when the user tries to scroll inside the table.

This crash happens because the  `layoutSubviews` function tries to use the shadow layer after the layer was already removed and released. This is an issue in iOS 5, because layers are automatically released when `removeFromSuperlayer` is called.

The fix creates a new shadow layer after the original shadow layer is released and removed. Generally, a layer shouldn't be used after `removeFromSuperlayer` is called.

Closes #733 as well.
