### PR TITLE
line 93~95 will fail when "destW" or "destH" is not integral.

### DIFF
--- a/src/Three20Style/Sources/UIImageAdditions.m
+++ b/src/Three20Style/Sources/UIImageAdditions.m
@@ -76,6 +76,8 @@ TT_FIX_CATEGORY_BUG(UIImageAdditions)
  * imageOrientation shows it to be necessary (and the rotate argument is YES).
  */
 - (UIImage*)transformWidth:(CGFloat)width height:(CGFloat)height rotate:(BOOL)rotate {
+  width = (int)(width+0.5); // round to integral
+  height = (int)(height+0.5);
   CGFloat destW = width;
   CGFloat destH = height;
   CGFloat sourceW = width;


### PR DESCRIPTION
Like this "CGBitmapContextCreate: unsupported parameter combination: 8 integer bits/component; 32 bits/pixel; 3-component color space; kCGImageAlphaNoneSkipLast; 3199 bytes/row."!

CGSize *size = image.size; //width : 600px
size.width can make 599.998
