### PR TITLE
Fix blank URL crash

### DIFF
--- a/src/Three20Network/Sources/TTRequestLoader.m
+++ b/src/Three20Network/Sources/TTRequestLoader.m
@@ -124,18 +124,19 @@ static const NSInteger kLoadMaxRetries = 2;
     [self performSelector:@selector(deliverDataResponse:) withObject:URL afterDelay:0.1];
     return;
   }
-  TTNetworkRequestStarted();
-
   TTURLRequest* request = _requests.count >= 1 ? [_requests objectAtIndex:0] : nil;
   
   // there are situations where urlPath is somehow nil (therefore crashing in
   // createNSURLRequest:URL:, even if we checked for non-blank values before 
   // adding the request to the queue.
-  if (!request.urlPath.length)
+  if (!request.urlPath.length) {
     [self cancel:request];
+    if (URL == nil)
+      return; // no url whatsoever, nothing to do here
+  }
   
+  TTNetworkRequestStarted();
   NSURLRequest* URLRequest = [_queue createNSURLRequest:request URL:URL];
-
   _connection = [[NSURLConnection alloc] initWithRequest:URLRequest delegate:self];
 }
 


### PR DESCRIPTION
This is a complementary fix related to <a href="https://github.com/facebook/three20/pull/717">pull request 717</a>. If the provided URL also happens to be nil, TTURLRequestQueue::createNSURLRequest will simply crash. This fix makes it a little more robust, and avoids attempting to request a blank URL.
