### PR TITLE
Fix popover crash in navigator

### DIFF
--- a/src/Three20UINavigator/Sources/TTBaseNavigator.m
+++ b/src/Three20UINavigator/Sources/TTBaseNavigator.m
@@ -345,9 +345,9 @@ __attribute__((weak_import));
     TT_RELEASE_SAFELY(_popoverController);
   }
 
-  _popoverController =  [[TTUIPopoverControllerClass() alloc] init];
+  _popoverController =  [[TTUIPopoverControllerClass() alloc]
+                         initWithContentViewController: controller];
   if (_popoverController != nil) {
-    [_popoverController setContentViewController:controller];
     [_popoverController setDelegate:self];
   }
 


### PR DESCRIPTION
When the TTBaseNavigator creates a new popover, it does it using the `-init` message.

This throws an exception on iOS 4.3 and iOS 5.1: the UIPopoverController designated initializer is actually `-initWithContentViewController:`.

The fix uses the correct message, and thus prevents the crash.
