### PR TITLE
Invalidate the `_editHoldTimer` before releasing `_buttons`

### DIFF
--- a/src/Three20UI/Sources/TTLauncherView.m
+++ b/src/Three20UI/Sources/TTLauncherView.m
@@ -800,6 +800,7 @@ static const NSInteger kDefaultColumnCount = 3;
     [pageCopy release];
   }
 
+  TT_INVALIDATE_TIMER(_editHoldTimer);
   TT_RELEASE_SAFELY(_buttons);
   [self setNeedsLayout];
 }
@@ -810,6 +811,8 @@ static const NSInteger kDefaultColumnCount = 3;
   if (_columnCount != columnCount) {
     _columnCount = columnCount;
     _rowCount = 0;
+
+    TT_INVALIDATE_TIMER(_editHoldTimer);
     TT_RELEASE_SAFELY(_buttons);
     [self setNeedsLayout];
   }


### PR DESCRIPTION
Invalidate the `_editHoldTimer` before releasing `_buttons` to avoid the crash which occurs when `editHoldTimer:` is called after the button which triggered it has been deallocated. If `setPages:` or `setColumnCount:` are called between when the button is touched and when the timer goes off one second later, the button the timer references will have been deallocated, leading to a crash.
