### PR TITLE
fixed a few iOS 6 deprecation warnings

### DIFF
--- a/src/Three20UI/Sources/TTPostController.m
+++ b/src/Three20UI/Sources/TTPostController.m
@@ -135,12 +135,7 @@ static const CGFloat kMarginY = 6.0f;
   _originalStatusBarStyle = app.statusBarStyle;
   _originalStatusBarHidden = app.statusBarHidden;
   if (!_originalStatusBarHidden) {
-#ifdef __IPHONE_3_2
-    if ([app respondsToSelector:@selector(setStatusBarHidden:withAnimation:)])
-      [app setStatusBarHidden:NO withAnimation:UIStatusBarAnimationSlide];
-    else
-#endif
-    [app setStatusBarHidden:NO animated:YES];
+    [app setStatusBarHidden:NO withAnimation:UIStatusBarAnimationSlide];
     [app setStatusBarStyle:UIStatusBarStyleBlackTranslucent animated:YES];
   }
   [_textView becomeFirstResponder];
@@ -150,12 +145,7 @@ static const CGFloat kMarginY = 6.0f;
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)hideKeyboard {
   UIApplication* app = [UIApplication sharedApplication];
-#ifdef __IPHONE_3_2
-  if ([app respondsToSelector:@selector(setStatusBarHidden:withAnimation:)])
-    [app setStatusBarHidden:_originalStatusBarHidden withAnimation:UIStatusBarAnimationSlide];
-  else
-#endif
-  [app setStatusBarHidden:_originalStatusBarHidden animated:YES];
+  [app setStatusBarHidden:_originalStatusBarHidden withAnimation:UIStatusBarAnimationSlide];
   [app setStatusBarStyle:_originalStatusBarStyle animated:NO];
   [_textView resignFirstResponder];
 }

--- a/src/Three20UI/Sources/UIViewAdditions.m
+++ b/src/Three20UI/Sources/UIViewAdditions.m
@@ -478,11 +478,13 @@ TT_FIX_CATEGORY_BUG(UIViewAdditions)
   CGPoint centerEnd = CGPointMake(floor(screenFrame.size.width/2 - self.width/2),
                                   screenFrame.size.height - floor(self.height/2));
 
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   return [NSDictionary dictionaryWithObjectsAndKeys:
           [NSValue valueWithCGRect:bounds], UIKeyboardBoundsUserInfoKey,
           [NSValue valueWithCGPoint:centerBegin], UIKeyboardCenterBeginUserInfoKey,
           [NSValue valueWithCGPoint:centerEnd], UIKeyboardCenterEndUserInfoKey,
           nil];
+#pragma GCC diagnostic warning "-Wdeprecated-declarations"
 }
 
 

--- a/src/Three20UICommon/Sources/UIViewControllerAdditions.m
+++ b/src/Three20UICommon/Sources/UIViewControllerAdditions.m
@@ -304,16 +304,10 @@ TT_FIX_CATEGORY_BUG(UIViewControllerAdditions)
                            objectForKey:@"UIStatusBarHidden"] boolValue];
 
   if (!statusBarHidden) {
-    #ifdef __IPHONE_3_2
-    if ([[UIApplication sharedApplication]
-         respondsToSelector:@selector(setStatusBarHidden:withAnimation:)])
-      [[UIApplication sharedApplication] setStatusBarHidden:!show
-                                              withAnimation:(animated
-                                                             ? UIStatusBarAnimationFade
-                                                             :UIStatusBarAnimationNone)];
-    else
-  #endif
-    [[UIApplication sharedApplication] setStatusBarHidden:!show animated:animated];
+    [[UIApplication sharedApplication] setStatusBarHidden:!show
+                                            withAnimation:(animated
+                                                           ? UIStatusBarAnimationFade
+                                                           :UIStatusBarAnimationNone)];
   }
 
   if (animated) {


### PR DESCRIPTION
Removed call to setStatusBarHidden:animated:, deprecated in iOS 6.
Removed some old code wrapped in __IPHONE_3_2 macro, since Three20 now targets iOS 4+.
Added pragma to ignore deprecated declarations in code handling keyboard notifications.
