### PR TITLE
Fixed rotation on iOS 6

### DIFF
--- a/src/Three20UINavigator/Sources/TTBaseNavigator.m
+++ b/src/Three20UINavigator/Sources/TTBaseNavigator.m
@@ -250,6 +250,7 @@ __attribute__((weak_import));
       [_rootContainer navigator:self setRootViewController:_rootViewController];
 
     } else {
+      [self.window setRootViewController:_rootViewController];
       [self.window addSubview:_rootViewController.view];
     }
   }


### PR DESCRIPTION
In order to have the rotation callbacks being called on iOS 6, we need to set the root view controller explictly on our UIWindow.
