### PR TITLE
Autogenerating GET url query string using the contents on the parameters dictionary

### DIFF
--- a/src/Three20Network/Headers/TTURLRequest.h
+++ b/src/Three20Network/Headers/TTURLRequest.h
@@ -128,7 +128,7 @@ extern const NSTimeInterval TTURLRequestUseQueueTimeout;
 @property (nonatomic, copy) NSString* contentType;
 
 /**
- * Parameters to use for an HTTP POST/PUT.
+ * Parameters to use for an HTTP GET/POST/PUT.
  */
 @property (nonatomic, readonly) NSMutableDictionary* parameters;
 

--- a/src/Three20Network/Sources/TTURLRequest.m
+++ b/src/Three20Network/Sources/TTURLRequest.m
@@ -134,7 +134,7 @@ const NSTimeInterval TTURLRequestUseQueueTimeout = -1.0;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 - (NSString*)description {
-  return [NSString stringWithFormat:@"<%@ %@>", [super description], _urlPath];
+  return [NSString stringWithFormat:@"<%@ %@>", [super description], self.urlPath];
 }
 
 
@@ -391,6 +391,16 @@ const NSTimeInterval TTURLRequestUseQueueTimeout = -1.0;
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark -
 #pragma mark Properties
+
+- (NSString*)urlPath {
+    NSString *result = _urlPath;
+    if (_urlPath
+        && [_parameters count] > 0
+        && !([_httpMethod isEqualToString:@"POST"] || [_httpMethod isEqualToString:@"PUT"])){
+        result = [_urlPath stringByAddingQueryDictionary:self.parameters];
+    }
+    return result;
+}
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/Three20Network/UnitTests/NetworkModelTests.m
+++ b/src/Three20Network/UnitTests/NetworkModelTests.m
@@ -29,6 +29,8 @@
 
 // Core
 #import "Three20Core/TTCorePreprocessorMacros.h"
+#import "Three20Core/NSStringAdditions.h"
+
 
 /**
  * Unit tests for the Network model found within Three20. These tests are a part of
@@ -141,6 +143,43 @@
 
   TT_RELEASE_SAFELY(model);
   TT_RELEASE_SAFELY(request);
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)testTTURLRequest_urlPath {
+    
+    NSBundle* testBundle = [NSBundle bundleWithIdentifier:@"com.facebook.three20.UnitTests"];
+    STAssertTrue(nil != testBundle, @"Unable to find the bundle %@", [NSBundle allBundles]);
+    
+    NSString* xmlDataPath = [[testBundle bundlePath]
+                             stringByAppendingPathComponent:@"testcase.xml"];
+    
+    TTURLRequest* request = [[TTURLRequest alloc] initWithURL:xmlDataPath delegate:nil];
+    
+    STAssertTrue([request.urlPath isEqualToString:xmlDataPath],
+                 @"The GET url path should be equal to the passed in the constructor");
+    
+    NSDictionary* parameters = [NSDictionary dictionaryWithObjectsAndKeys:
+                                @"value1", @"parameter1", @"value2", @"parameter2", nil];
+    [request.parameters addEntriesFromDictionary:parameters];
+    
+    STAssertFalse([request.urlPath isEqualToString:xmlDataPath],
+                  @"The GET url path should be different to the passed in the constructor.");
+    
+    STAssertTrue([request.urlPath isEqualToString:
+                  [xmlDataPath stringByAddingQueryDictionary:parameters]],
+                 @"The url is formed by adding the parameters to the query");
+    
+    request.httpMethod = @"POST";
+    STAssertTrue([request.urlPath isEqualToString:xmlDataPath],
+                 @"The POST url path should be the same to the passed in the constructor");
+    
+    request.httpMethod = @"PUT";
+    STAssertTrue([request.urlPath isEqualToString:xmlDataPath],
+                 @"The PUT url path should be the same to the passed in the constructor");
+    
+    TT_RELEASE_SAFELY(request);
 }
 
 


### PR DESCRIPTION
An easy way to change between GET and POST methods using the same code
structure. Depending the data on parameters and the httpMethod the property urlPath will display the correct url, filling with data the querystring (for GET requests) or the requestBody (for PUT/POST requests). Also added tests.

Starting with the TTURLRequest object:

```
TTURLRequest *request = [[TTURLRequest alloc] initWithURL:@"http://sample.com" delegate:nil];
```

If the parameters dictionary is empty, `request.urlPath` will show:

```
http://sample.com 
```

If we fill the parameters dictionary

```
NSDictionary* parameters = [NSDictionary dictionaryWithObjectsAndKeys:
                                @"value1", @"parameter1", @"value2", @"parameter2", nil];
[request.parameters addEntriesFromDictionary:parameters];
```

The method `request.urlPath` now will show:

```
http://sample.com?parameter2=value2&parameter1=value1
```

Using the same `request` object and changing httpMethod to POST or PUT, `request.urlPath` will show:

```
http://sample.com
```

And the parameters will be added to de requestBody
